### PR TITLE
v0.6.2: portable DebugType so .snupkg actually ships symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: nuget-package
-          path: ./artifacts/*.nupkg
+          # Capture both .nupkg and .snupkg so the publish job's
+          # `dotnet nuget push *.nupkg` can also push the matching
+          # symbol package next to it.
+          path: ./artifacts/*nupkg
 
   # Keychain backend is macOS-only. This job runs the same test suite on a
   # real macOS runner so the Keychain tests actually exercise

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.2] — 2026-05-03
+
+### Changed
+
+- **Symbol packaging.** Switched `<DebugType>` from `embedded` to `portable`
+  so the published `.snupkg` actually contains `.pdb` files. The previous
+  combination produced an empty `.snupkg`; nuget.org rejects empty symbol
+  packages with HTTP 400. Until now the workflow's `upload-artifact`
+  filter (`*.nupkg`) silently dropped the broken symbol package on its
+  way to the publish job, so the failure stayed invisible — but no
+  symbols ever reached nuget.org's symbol server. Consumers debugging
+  into the library now get sources via the symbol server out of the box.
+- **CI artifact path.** `upload-artifact` now captures `*nupkg` (both
+  `.nupkg` and `.snupkg`) so the publish job pushes both files.
+
+---
+
 ## [0.6.1] — 2026-05-03
 
 ### Fixed
@@ -100,6 +117,7 @@ Consumers needed a way to read a specific stored credential's secret at runtime 
 - SourceLink, deterministic builds, embedded symbols, published symbol packages.
 - `TreatWarningsAsErrors=true`, `AnalysisLevel=latest` — zero-warning public API.
 
+[0.6.2]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.2
 [0.6.1]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.1
 [0.5.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.5.0
 [0.4.2]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.4.2

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -17,7 +17,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>0.6.1</Version>
+		<Version>0.6.2</Version>
 		<Authors>Stuart Meeks</Authors>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
@@ -36,7 +36,7 @@
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<DebugType>embedded</DebugType>
+		<DebugType>portable</DebugType>
 		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 


### PR DESCRIPTION
## Summary

Same fix as the rest of the NextIteration.SpectreConsole.* family.

The previous combo — `IncludeSymbols=true` + `SymbolPackageFormat=snupkg` + `DebugType=embedded` — produces an empty `.snupkg` (no `.pdb` files; debug info is embedded inside the `.dll`). nuget.org rejects empty symbol packages with HTTP 400. Until now the workflow's `upload-artifact` filter (`*.nupkg`) silently dropped the symbol package on its way to the publish job, so the failure stayed invisible — but no symbols ever reached nuget.org.

`<DebugType>portable</DebugType>` produces a real `.pdb` alongside the `.dll`. The `.snupkg` now contains it; nuget.org accepts the symbol upload; consumers debugging into the library get sources via the symbol server.

`upload-artifact` path also changed from `*.nupkg` to `*nupkg` so both files survive the artifact handoff.

## Test plan

- [x] CI green (including the macOS Keychain test job)
- [ ] After merge: tag `v0.6.2`, verify nuget.org indexes both `.nupkg` and `.snupkg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
