### PR TITLE
v0.6.3: dependency updates and NuGet trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
 
+    permissions:
+      id-token: write   # enable GitHub OIDC token issuance for NuGet trusted publishing
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -107,5 +111,15 @@ jobs:
           name: nuget-package
           path: ./artifacts
 
+      # Exchange the GitHub OIDC token for a short-lived (1 hour) nuget.org
+      # API key. Requires a Trusted Publishing policy on nuget.org bound to
+      # this repo + workflow file (ci.yml). NUGET_USER is the nuget.org
+      # account/profile name (not an email).
+      - name: NuGet login (OIDC → temporary API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish to NuGet
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.3] — 2026-06-10
+
+### Changed
+
+- **Dependency updates.** Bumped `Microsoft.Extensions.DependencyInjection.Abstractions`,
+  `Microsoft.Extensions.Http`, and `System.Security.Cryptography.ProtectedData`
+  to `10.0.9`; `Spectre.Console` to `0.56.0`; and `Microsoft.SourceLink.GitHub`
+  to `10.0.300`. Test-only dependencies updated as well
+  (`Microsoft.NET.Test.Sdk` `18.6.0`, `xunit` `2.9.3`,
+  `xunit.runner.visualstudio` `3.1.5`, `coverlet.collector` `10.0.1`).
+  `Spectre.Console.Cli` stays at `0.55.0` (latest stable). No public API change.
+- **NuGet trusted publishing.** The `publish` CI job now uses OIDC-based
+  [trusted publishing](https://learn.microsoft.com/nuget/nuget-org/trusted-publishing):
+  it exchanges the GitHub OIDC token for a short-lived nuget.org API key via
+  `NuGet/login@v1` instead of a long-lived `NUGET_API_KEY` secret.
+
+---
+
 ## [0.6.2] — 2026-05-03
 
 ### Changed

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -17,7 +17,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>0.6.2</Version>
+		<Version>0.6.3</Version>
 		<Authors>Stuart Meeks</Authors>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
@@ -45,12 +45,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.5" />
-		<PackageReference Include="Spectre.Console" Version="0.55.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
+		<PackageReference Include="Spectre.Console" Version="0.56.0" />
 		<PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<None Include="icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -22,13 +22,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

- Update all NuGet package references to latest (none were pinned).
- Switch the `publish` CI job to OIDC-based [NuGet trusted publishing](https://learn.microsoft.com/nuget/nuget-org/trusted-publishing), replacing the long-lived `NUGET_API_KEY` secret.
- Bump version to `0.6.3` and add a CHANGELOG entry.

### Package updates

**Library**
| Package | Old → New |
|---|---|
| Microsoft.Extensions.DependencyInjection.Abstractions | 10.0.5 → 10.0.9 |
| Microsoft.Extensions.Http | 10.0.5 → 10.0.9 |
| System.Security.Cryptography.ProtectedData | 10.0.5 → 10.0.9 |
| Spectre.Console | 0.55.2 → 0.56.0 |
| Microsoft.SourceLink.GitHub | 8.0.0 → 10.0.300 |
| Spectre.Console.Cli | 0.55.0 (already latest stable) |

**Tests:** Microsoft.NET.Test.Sdk 18.6.0, xunit 2.9.3, xunit.runner.visualstudio 3.1.5, coverlet.collector 10.0.1.

### Trusted publishing

The `publish` job now requests `id-token: write`, exchanges the GitHub OIDC token for a short-lived nuget.org API key via `NuGet/login@v1`, and pushes with that key. Requires a trusted-publishing policy on nuget.org bound to this repo + `ci.yml`, and a `NUGET_USER` repo secret (configured separately).

## Test plan

- [x] `dotnet build -c Release` — clean (0 warnings, `TreatWarningsAsErrors` on)
- [x] `dotnet test -c Release` — all 145 tests pass
- [ ] First tagged publish (`v0.6.3`) exercises the trusted-publishing flow end to end