### PR TITLE
v0.7.0: multi-target net8.0 and net10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.0] — 2026-06-20
+
+### Added
+
+- **Multi-targeting `net8.0` and `net10.0`.** The package now ships assemblies for
+  both `net8.0` (current LTS) and `net10.0`, so consumers no longer need the newest
+  runtime to take a dependency. All dependencies already provide `net8.0` assets, so
+  the dependency graph is unchanged. The only source adjustment was swapping the
+  `net9.0+` `System.Threading.Lock` used to guard libsecret symbol resolution for a
+  plain `object` lock; behaviour is identical. No public API change.
+
+---
+
 ## [0.6.3] — 2026-06-10
 
 ### Changed
@@ -135,6 +148,8 @@ Consumers needed a way to read a specific stored credential's secret at runtime 
 - SourceLink, deterministic builds, embedded symbols, published symbol packages.
 - `TreatWarningsAsErrors=true`, `AnalysisLevel=latest` — zero-warning public API.
 
+[0.7.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.7.0
+[0.6.3]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.3
 [0.6.2]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.2
 [0.6.1]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.1
 [0.5.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.5.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Authors>Stuart Meeks</Authors>

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
@@ -17,7 +17,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>0.6.3</Version>
+		<Version>0.7.0</Version>
 		<Authors>Stuart Meeks</Authors>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretInterop.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretInterop.cs
@@ -309,7 +309,7 @@ internal static partial class LibsecretInterop
 
     private static readonly Dictionary<string, IntPtr> _libraryHandles = [];
     private static readonly Dictionary<string, IntPtr> _symbolCache = [];
-    private static readonly Lock _resolveLock = new();
+    private static readonly object _resolveLock = new();
 
     private static IntPtr ResolveExport(string library, string symbolName)
     {


### PR DESCRIPTION
## Summary

Broadens the package from `net10.0`-only to multi-target **`net8.0;net10.0`** (net8.0 = current LTS), so consumers no longer need the newest runtime to take a dependency.

All dependencies (Spectre.Console, Spectre.Console.Cli, `Microsoft.Extensions.*` v10, `System.Security.Cryptography.ProtectedData`) already ship `net8.0` assets, so the dependency graph is unchanged and no conditional package references were needed.

## Changes

- **`LibsecretInterop.cs`** — the only API blocking net8.0 was `System.Threading.Lock` (net9+) guarding libsecret native-symbol resolution; swapped for a plain `object` lock. Behaviour is identical.
- **`Directory.Build.props`** — removed the global `<TargetFramework>net10.0</TargetFramework>`; a non-empty singular `TargetFramework` makes MSBuild ignore `TargetFrameworks` and silently stay single-targeted.
- **`src/…csproj`** — `<TargetFramework>net10.0</TargetFramework>` → `<TargetFrameworks>net8.0;net10.0</TargetFrameworks>`; `Version` `0.6.3` → `0.7.0`.
- **`CHANGELOG.md`** — added `[0.7.0]` entry; backfilled the missing `[0.6.3]` link reference.

## Verification

- `dotnet build -c Release` — both `net8.0` and `net10.0` compile cleanly, **0 warnings / 0 errors** (with `TreatWarningsAsErrors` + `AnalysisLevel=latest`).
- `dotnet pack` — `0.7.0.nupkg` contains both `lib/net8.0/` and `lib/net10.0/` assemblies + XML docs; `.snupkg` produced.
- `dotnet test -c Release` — **145/145 passed** (on net10; the net8.0 build is compile-verified — the only source delta between the two builds is the one `lock` line).

No public API change.