### PR TITLE
v0.7.1: per-TFM dependency floors and servicing bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.1] — 2026-07-24
+
+### Changed
+
+- **Per-target-framework dependency floors.** A `PackageReference` version in a
+  library is a *minimum floor* NuGet forces on every consumer, so flooring the
+  runtime-aligned Microsoft platform packages at a single `10.0.x` dragged
+  `net8.0` (LTS) consumers off their own `8.0.x` servicing line. Each target now
+  floors at its aligned major: the `net8.0` build floors
+  `Microsoft.Extensions.DependencyInjection.Abstractions` at `8.0.2`,
+  `Microsoft.Extensions.Http` at `8.0.1`, and
+  `System.Security.Cryptography.ProtectedData` at `8.0.0`; the `net10.0` build
+  floors all three at `10.0.10`. No public API change.
+- **Dependency updates.** Bumped `Spectre.Console` to `0.57.2` and
+  `Microsoft.SourceLink.GitHub` to `10.0.301`; test-only `Microsoft.NET.Test.Sdk`
+  to `18.8.1`. `Spectre.Console.Cli` stays at `0.55.0` (latest stable).
+
+---
+
 ## [0.7.0] — 2026-06-20
 
 ### Added

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -17,7 +17,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>0.7.0</Version>
+		<Version>0.7.1</Version>
 		<Authors>Stuart Meeks</Authors>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
@@ -45,14 +45,31 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
-		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.9" />
-		<PackageReference Include="Spectre.Console" Version="0.56.0" />
+		<!-- Common to all target frameworks. -->
+		<PackageReference Include="Spectre.Console" Version="0.57.2" />
 		<PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<None Include="icon.png" Pack="true" PackagePath="" />
+	</ItemGroup>
+
+	<!--
+		Per-TFM floors for the runtime-aligned Microsoft platform packages. A
+		PackageReference version is a minimum floor NuGet forces on consumers,
+		so flooring these at a single 10.0.x would drag net8 (LTS) consumers off
+		their own 8.0.x servicing line. Each target instead floors at its own
+		aligned major: net8 -> 8.0.x, net10 -> 10.0.x.
+	-->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
 	</ItemGroup>
 
 </Project>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
 		<PackageReference Include="xunit" Version="2.9.3" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Routine maintenance release. Headline change is adopting **per-target-framework dependency floors** for the runtime-aligned Microsoft platform packages, plus servicing bumps. No public API change.

### Why per-TFM floors
A `PackageReference` version in a library is a **minimum floor** NuGet forces on every downstream consumer. Flooring the Microsoft platform packages at a single `10.0.x` dragged `net8.0` (LTS) consumers off their own `8.0.x` servicing line, even though a `net8.0` asset shipped in 0.7.0. Each target now floors at its aligned major.

### Changed
- **Per-TFM floors** for the Microsoft platform packages:
  - `net8.0`: `Microsoft.Extensions.DependencyInjection.Abstractions` `8.0.2`, `Microsoft.Extensions.Http` `8.0.1`, `System.Security.Cryptography.ProtectedData` `8.0.0`
  - `net10.0`: all three at `10.0.10`
- **Dependency bumps**: `Spectre.Console` → `0.57.2`, `Microsoft.SourceLink.GitHub` → `10.0.301`, test-only `Microsoft.NET.Test.Sdk` → `18.8.1`
- `Spectre.Console.Cli` stays `0.55.0` (latest stable; `Spectre.Console` is deliberately not lowered — pre-1.0 makes a low floor meaningless)

### Verification
- `dotnet build -c Release` — both TFMs, 0 warnings (`TreatWarningsAsErrors` on)
- `dotnet test -c Release` — 145/145 pass
- Inspected the produced `.nuspec`: `net8.0` dependency group shows the `8.0.x` floors and `net10.0` shows `10.0.10`, as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)