### PR TITLE
chore: bump SourceLink, Test.Sdk, and xunit VS runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Dependency updates (no consumer impact).** Bumped `Microsoft.SourceLink.GitHub`
+  to `10.0.400`; test-only `Microsoft.NET.Test.Sdk` to `18.9.0` and
+  `xunit.runner.visualstudio` to `4.0.0`. SourceLink is referenced with
+  `PrivateAssets="All"` and the other two are test-only, so none of these reach
+  consumers and no dependency floor changed. The `net8.0` floors are already at
+  the top of their `8.0.x` servicing lines, and the `net10.0` floors are left at
+  `10.0.10` deliberately rather than raising a floor consumers would be forced to
+  match. `Spectre.Console` (`0.57.2`) and `Spectre.Console.Cli` (`0.55.0`) remain
+  the latest stable releases of each. No public API change.
+
 ## [0.7.1] — 2026-07-24
 
 ### Changed

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -48,7 +48,7 @@
 		<!-- Common to all target frameworks. -->
 		<PackageReference Include="Spectre.Console" Version="0.57.2" />
 		<PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<None Include="icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -22,9 +22,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
Three dependency bumps, none of which reach consumers.

| Package | From | To | Scope |
|---|---|---|---|
| `Microsoft.SourceLink.GitHub` | 10.0.301 | 10.0.400 | `PrivateAssets="All"` — never flows to consumers |
| `Microsoft.NET.Test.Sdk` | 18.8.1 | 18.9.0 | test-only |
| `xunit.runner.visualstudio` | 3.1.5 | 4.0.0 | test-only |

The runner's jump to 4.0.0 looks like a breaking major but is a drop-in here: its nuspec describes it as "Capable of running xUnit.net v1, v2, and v3 tests", so it happily runs the current `xunit` 2.9.3 suite.

### No dependency floor moved

A `PackageReference` version is a minimum floor NuGet forces on consumers, per the reasoning already documented in `0.7.1`:

- The `net8.0` floors (`8.0.2` / `8.0.1` / `8.0.0`) are already the *last* `8.0.x` releases of those three packages — nothing to bump.
- The `net10.0` floors stay at `10.0.10`. `10.0.11` exists, but there is no advisory behind it (`dotnet list package --vulnerable --include-transitive` is clean), so raising a floor consumers must match buys nothing.
- `Spectre.Console` (`0.57.2`) and `Spectre.Console.Cli` (`0.55.0`) are each already the latest stable; everything newer is alpha. The version gap between them is just independent versioning, not a mismatch.

### Verification

- `dotnet build -c Release` — succeeded, **0 warnings, 0 errors**, both `net8.0` and `net10.0`.
- `dotnet test -c Release` — **145 passed, 0 failed**.
- The two `NJsonSchema.dll` package-validation notes in the build log are pre-existing; they appear identically on unmodified `main`.

### Follow-up (not in this PR)

`xunit` 2.9.3 is flagged **deprecated (Legacy)** by NuGet, with `xunit.v3` as the alternative. Worth noting there is no `xunit.v4` package — the `xunit.v3` package id is now at **version 4.0.0**, which is why the runner in this PR is also 4.0.0. That migration is tracked separately since it changes the test project's output type and runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)