### PR TITLE
chore: migrate test suite from xUnit.net v2 to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Migrated the test suite from xUnit.net v2 to v3.** `xunit` `2.9.3` was
+  flagged deprecated ("Legacy") on NuGet and `2.9.3` is the terminal v2 release,
+  so no further fixes were coming. Replaced it with `xunit.v3` `4.0.0`. Note the
+  package id keeps the `.v3` suffix while its *version* is now `4.0.0` — there is
+  no `xunit.v4` package. Test-project-only; no public API or packaging change.
+  - The test project is now `<OutputType>Exe</OutputType>`, which v3 requires
+    (its targets hard-error otherwise); the runner generates the entry point.
+  - xUnit.net v3 builds on Microsoft.Testing.Platform (MTP), and the .NET 10 SDK
+    refuses to run MTP test projects through the legacy VSTest target. A root
+    `global.json` opts `dotnet test` into the MTP runner. The CI `dotnet test`
+    invocation is unchanged.
+  - Dropped `Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio`, and
+    `coverlet.collector`: all three are VSTest-only and MTP replaces the runner
+    entirely. Coverage was never actually collected (no `--collect` anywhere in
+    CI or scripts), so nothing regressed; if coverage is wanted later, the MTP
+    equivalent is `Microsoft.Testing.Extensions.CodeCoverage`.
+  - Fixed 30 new `xunit.analyzers` 2.0.0 findings surfaced by v3, which
+    `TreatWarningsAsErrors` promotes to errors: 15 × `xUnit2033` (use
+    `Assert.Single`'s return value instead of re-indexing `[0]`) and 15 ×
+    `xUnit1051` (thread `TestContext.Current.CancellationToken` into calls that
+    accept one, so cancellation is responsive).
+
 - **Dependency updates (no consumer impact).** Bumped `Microsoft.SourceLink.GitHub`
   to `10.0.400`; test-only `Microsoft.NET.Test.Sdk` to `18.9.0` and
   `xunit.runner.visualstudio` to `4.0.0`. SourceLink is referenced with

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -2,6 +2,9 @@
 
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
+		<!-- xUnit.net v3 test projects must be executable; the runner
+		     generates the entry point. -->
+		<OutputType>Exe</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -22,16 +25,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
+		<PackageReference Include="xunit.v3" Version="4.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/AtomicFileTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/AtomicFileTests.cs
@@ -15,7 +15,7 @@ public sealed class AtomicFileTests
 
         await AtomicFile.WriteAllTextAsync(target, "hello");
 
-        Assert.Equal("hello", await File.ReadAllTextAsync(target));
+        Assert.Equal("hello", await File.ReadAllTextAsync(target, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public sealed class AtomicFileTests
 
         await AtomicFile.WriteAllBytesAsync(target, payload);
 
-        Assert.Equal(payload, await File.ReadAllBytesAsync(target));
+        Assert.Equal(payload, await File.ReadAllBytesAsync(target, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -40,8 +40,8 @@ public sealed class AtomicFileTests
 
         // Only the final file should exist — no stray .tmp files.
         var files = Directory.GetFiles(temp.Path);
-        Assert.Single(files);
-        Assert.Equal(target, files[0]);
+        var only = Assert.Single(files);
+        Assert.Equal(target, only);
     }
 
     [Fact]
@@ -49,11 +49,11 @@ public sealed class AtomicFileTests
     {
         using var temp = new TempDir();
         var target = Path.Combine(temp.Path, "file.txt");
-        await File.WriteAllTextAsync(target, "original");
+        await File.WriteAllTextAsync(target, "original", TestContext.Current.CancellationToken);
 
         await AtomicFile.WriteAllTextAsync(target, "replaced");
 
-        Assert.Equal("replaced", await File.ReadAllTextAsync(target));
+        Assert.Equal("replaced", await File.ReadAllTextAsync(target, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -64,13 +64,13 @@ public sealed class AtomicFileTests
         // content — never an empty/half-written target.
         using var temp = new TempDir();
         var target = Path.Combine(temp.Path, "file.txt");
-        await File.WriteAllTextAsync(target, "original");
+        await File.WriteAllTextAsync(target, "original", TestContext.Current.CancellationToken);
 
         // Hard to probe the race deterministically, so at minimum assert
         // that the post-write state is fully the new content.
         await AtomicFile.WriteAllTextAsync(target, "replaced-content-that-is-longer");
 
-        Assert.Equal("replaced-content-that-is-longer", await File.ReadAllTextAsync(target));
+        Assert.Equal("replaced-content-that-is-longer", await File.ReadAllTextAsync(target, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -101,7 +101,7 @@ public sealed class AtomicFileTests
 
         await AtomicFile.WriteAllTextAsync(target, "hello", unixMode: null);
 
-        Assert.Equal("hello", await File.ReadAllTextAsync(target));
+        Assert.Equal("hello", await File.ReadAllTextAsync(target, TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -121,7 +121,7 @@ public sealed class AtomicFileTests
         };
         await Task.WhenAll(tasks);
 
-        var final = await File.ReadAllTextAsync(target);
+        var final = await File.ReadAllTextAsync(target, TestContext.Current.CancellationToken);
         Assert.True(final is "writer-a" or "writer-b", $"expected one of the two writes to win, got: {final}");
 
         // No stragglers.

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -84,12 +84,12 @@ public sealed class FileCredentialManagerTests
 
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        Assert.Equal(accountId, list[0].AccountId);
-        Assert.Equal("prod", list[0].AccountName);
-        Assert.Equal("Adobe", list[0].ProviderName);
-        Assert.Equal("Production", list[0].Environment);
-        Assert.False(list[0].IsSelected);
+        var credential = Assert.Single(list);
+        Assert.Equal(accountId, credential.AccountId);
+        Assert.Equal("prod", credential.AccountName);
+        Assert.Equal("Adobe", credential.ProviderName);
+        Assert.Equal("Production", credential.Environment);
+        Assert.False(credential.IsSelected);
     }
 
     [Fact]
@@ -103,10 +103,10 @@ public sealed class FileCredentialManagerTests
         var adobe = (await manager.ListCredentialsAsync("Adobe")).ToList();
         var airtable = (await manager.ListCredentialsAsync("Airtable")).ToList();
 
-        Assert.Single(adobe);
-        Assert.Single(airtable);
-        Assert.Equal("Adobe", adobe[0].ProviderName);
-        Assert.Equal("Airtable", airtable[0].ProviderName);
+        var adobeCredential = Assert.Single(adobe);
+        var airtableCredential = Assert.Single(airtable);
+        Assert.Equal("Adobe", adobeCredential.ProviderName);
+        Assert.Equal("Airtable", airtableCredential.ProviderName);
     }
 
     [Fact]
@@ -394,11 +394,10 @@ public sealed class FileCredentialManagerTests
         _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"abcd1234\"}");
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        var fields = list[0].DisplayFields;
-        Assert.Single(fields);
-        Assert.Equal("Fingerprint", fields[0].Key);
-        Assert.Equal("abcd1234", fields[0].Value);
+        var credential = Assert.Single(list);
+        var field = Assert.Single(credential.DisplayFields);
+        Assert.Equal("Fingerprint", field.Key);
+        Assert.Equal("abcd1234", field.Value);
     }
 
     [Fact]
@@ -428,9 +427,9 @@ public sealed class FileCredentialManagerTests
         var second = CreateManager(temp.Path);
         var list = (await second.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        Assert.Equal(accountId, list[0].AccountId);
-        Assert.True(list[0].IsSelected);
+        var credential = Assert.Single(list);
+        Assert.Equal(accountId, credential.AccountId);
+        Assert.True(credential.IsSelected);
         Assert.Equal("{\"key\":\"v\"}", await second.GetSelectedCredentialAsync("Adobe"));
     }
 

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -87,12 +87,12 @@ public sealed class KeychainCredentialManagerTests : IDisposable
 
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        Assert.Equal(accountId, list[0].AccountId);
-        Assert.Equal("prod", list[0].AccountName);
-        Assert.Equal("Adobe", list[0].ProviderName);
-        Assert.Equal("Production", list[0].Environment);
-        Assert.False(list[0].IsSelected);
+        var credential = Assert.Single(list);
+        Assert.Equal(accountId, credential.AccountId);
+        Assert.Equal("prod", credential.AccountName);
+        Assert.Equal("Adobe", credential.ProviderName);
+        Assert.Equal("Production", credential.Environment);
+        Assert.False(credential.IsSelected);
     }
 
     [Fact]
@@ -106,10 +106,10 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         var adobe = (await manager.ListCredentialsAsync("Adobe")).ToList();
         var airtable = (await manager.ListCredentialsAsync("Airtable")).ToList();
 
-        Assert.Single(adobe);
-        Assert.Single(airtable);
-        Assert.Equal("Adobe", adobe[0].ProviderName);
-        Assert.Equal("Airtable", airtable[0].ProviderName);
+        var adobeCredential = Assert.Single(adobe);
+        var airtableCredential = Assert.Single(airtable);
+        Assert.Equal("Adobe", adobeCredential.ProviderName);
+        Assert.Equal("Airtable", airtableCredential.ProviderName);
     }
 
     [Fact]
@@ -330,10 +330,10 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"xyz\"}");
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        Assert.Single(list[0].DisplayFields);
-        Assert.Equal("Fingerprint", list[0].DisplayFields[0].Key);
-        Assert.Equal("xyz", list[0].DisplayFields[0].Value);
+        var credential = Assert.Single(list);
+        var field = Assert.Single(credential.DisplayFields);
+        Assert.Equal("Fingerprint", field.Key);
+        Assert.Equal("xyz", field.Value);
     }
 
     private sealed class FakeAdobeSummaryProvider : ICredentialSummaryProvider

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -124,12 +124,12 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
 
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        Assert.Equal(accountId, list[0].AccountId);
-        Assert.Equal("prod", list[0].AccountName);
-        Assert.Equal("Adobe", list[0].ProviderName);
-        Assert.Equal("Production", list[0].Environment);
-        Assert.False(list[0].IsSelected);
+        var credential = Assert.Single(list);
+        Assert.Equal(accountId, credential.AccountId);
+        Assert.Equal("prod", credential.AccountName);
+        Assert.Equal("Adobe", credential.ProviderName);
+        Assert.Equal("Production", credential.Environment);
+        Assert.False(credential.IsSelected);
     }
 
     [Fact]
@@ -354,10 +354,10 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
         _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"xyz\"}");
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
-        Assert.Single(list);
-        Assert.Single(list[0].DisplayFields);
-        Assert.Equal("Fingerprint", list[0].DisplayFields[0].Key);
-        Assert.Equal("xyz", list[0].DisplayFields[0].Value);
+        var credential = Assert.Single(list);
+        var field = Assert.Single(credential.DisplayFields);
+        Assert.Equal("Fingerprint", field.Key);
+        Assert.Equal("xyz", field.Value);
     }
 
     private sealed class FakeAdobeSummaryProvider : ICredentialSummaryProvider

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/SelectionsLockTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/SelectionsLockTests.cs
@@ -13,7 +13,7 @@ public sealed class SelectionsLockTests
         using var temp = new TempDir();
         var lockPath = Path.Combine(temp.Path, "selections.json.lock");
 
-        using var held = await SelectionsLock.AcquireAsync(lockPath);
+        using var held = await SelectionsLock.AcquireAsync(lockPath, TestContext.Current.CancellationToken);
 
         // Successful acquisition is the assertion; we'd hit the IOException
         // path below if the contract were broken.
@@ -26,21 +26,21 @@ public sealed class SelectionsLockTests
         using var temp = new TempDir();
         var lockPath = Path.Combine(temp.Path, "selections.json.lock");
 
-        var first = await SelectionsLock.AcquireAsync(lockPath);
+        var first = await SelectionsLock.AcquireAsync(lockPath, TestContext.Current.CancellationToken);
 
         // Kick off a contender — it should park inside the backoff loop until
         // we dispose the holder, then proceed.
-        var contender = SelectionsLock.AcquireAsync(lockPath);
+        var contender = SelectionsLock.AcquireAsync(lockPath, TestContext.Current.CancellationToken);
 
         // Give the contender a moment to land inside its retry loop, then
         // release. If the lock semantics are broken the contender would have
         // already completed by now.
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
         Assert.False(contender.IsCompleted, "contender completed while lock was held");
 
         first.Dispose();
 
-        using var second = await contender.WaitAsync(TimeSpan.FromSeconds(5));
+        using var second = await contender.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         Assert.NotNull(second);
     }
 
@@ -50,12 +50,12 @@ public sealed class SelectionsLockTests
         using var temp = new TempDir();
         var lockPath = Path.Combine(temp.Path, "selections.json.lock");
 
-        (await SelectionsLock.AcquireAsync(lockPath)).Dispose();
+        (await SelectionsLock.AcquireAsync(lockPath, TestContext.Current.CancellationToken)).Dispose();
 
         // DeleteOnClose should clean up the sentinel file when the holder
         // disposes; a fresh acquirer must succeed without seeing a stale
         // lock.
-        using var second = await SelectionsLock.AcquireAsync(lockPath);
+        using var second = await SelectionsLock.AcquireAsync(lockPath, TestContext.Current.CancellationToken);
         Assert.NotNull(second);
     }
 }


### PR DESCRIPTION
Follow-up to #6. `xunit` 2.9.3 is flagged **deprecated ("Legacy")** on NuGet and is the terminal v2 release, so no further fixes were coming.

### There is no `xunit.v4`

Worth stating up front, because the numbering is confusing: the package id keeps the `.v3` suffix while its **version** is now `4.0.0`. `xunit.v4` returns a 404 on NuGet. So `xunit.v3` 4.0.0 *is* the latest xunit — which is also why the VS runner in #6 went to 4.0.0.

| | Before | After |
|---|---|---|
| Test framework | `xunit` 2.9.3 (deprecated) | `xunit.v3` 4.0.0 |
| Runner | VSTest | Microsoft.Testing.Platform |
| `Microsoft.NET.Test.Sdk` | 18.9.0 | removed |
| `xunit.runner.visualstudio` | 4.0.0 | removed |
| `coverlet.collector` | 10.0.1 | removed |

### Why the runner had to change

v3 builds on Microsoft.Testing.Platform, and the .NET 10 SDK hard-refuses to run MTP test projects through the legacy VSTest target:

```
error : Testing with VSTest target is no longer supported by Microsoft.Testing.Platform
on .NET 10 SDK and later.
```

There is no VSTest-only variant to fall back on — `xunit.v3.core` 4.0.0 also depends on `xunit.v3.core.mtp-v2`, so MTP is the only path at this version. A root `global.json` opts `dotnet test` into the MTP runner. It deliberately **does not pin an SDK version**, so CI's `10.0.x` setup is unaffected, and **the CI `dotnet test` invocation is unchanged** (verified locally with the exact command including `--verbosity normal`).

The three removed packages are all VSTest-only; MTP replaces the runner entirely. Two of them were bumped in #6 — those bumps were correct for xunit v2, and v3 simply makes them moot. Coverage was never actually collected (no `--collect` anywhere in CI or scripts), so nothing regressed; the MTP equivalent, if wanted later, is `Microsoft.Testing.Extensions.CodeCoverage`.

### Analyzer fixes

`xunit.analyzers` 2.0.0 ships with v3 and surfaced 30 new findings, which this repo's `TreatWarningsAsErrors` promotes to hard errors:

- **15 × `xUnit2033`** — use `Assert.Single`'s return value instead of re-indexing `[0]`:
  ```diff
  -        Assert.Single(list);
  -        Assert.Equal(accountId, list[0].AccountId);
  +        var credential = Assert.Single(list);
  +        Assert.Equal(accountId, credential.AccountId);
  ```
- **15 × `xUnit1051`** — thread `TestContext.Current.CancellationToken` into calls that accept one, so cancellation is responsive.

The suite otherwise needed no source changes: it only ever used `[Fact]`, `[Theory]`, `[InlineData]`, plain `Assert`, and `IDisposable`, with no `IAsyncLifetime`, fixtures, collections, `ITestOutputHelper`, or `Xunit.Abstractions`.

### Verification

- Clean `dotnet build -c Release` from wiped `obj`/`bin` — **0 warnings, 0 errors**.
- `dotnet test -c Release --no-build --verbosity normal` (the exact CI command) — **145 passed, 0 failed**.
- No production code, public API, or packaging change.

### A note on timing

An early run of mine clocked 3m50s and looked like a regression; that measurement was taken while a background CI-watcher was saturating this 1-core sandbox. Re-measured cleanly, v3 runs in **~44–52s** against v2's **~53s** on the same box, with identical ~39s CPU time. No meaningful difference. Worth knowing regardless: v3 defaults `maxThreads` to the core count, so on a 1-core machine it cannot overlap this suite's I/O waits — `-maxThreads 4.0x` cut a contended 97s run to 61s. I have **not** added any parallelism tuning, since CI runners have multiple cores and tuning for a pathological 1-core box would be the wrong default. Happy to add a `xunit.runner.json` if you'd like it anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)