### PR TITLE
docs: state both target frameworks accurately in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   match. `Spectre.Console` (`0.57.2`) and `Spectre.Console.Cli` (`0.55.0`) remain
   the latest stable releases of each. No public API change.
 
+### Fixed
+
+- **README now states the supported target frameworks accurately.** It claimed `net10.0`
+  only — in the .NET badge, the install section, and Requirements — even though the package
+  has multi-targeted `net8.0;net10.0` since 0.7.0. The documented dependency floors were
+  stale too: `Spectre.Console` 0.54+ / `Spectre.Console.Cli` 0.53+ against actual floors of
+  0.57.2 / 0.55.0, and a single `10.0+` floor for
+  `Microsoft.Extensions.DependencyInjection.Abstractions` where 0.7.1 deliberately made
+  those floors per-target-framework. Requirements now records the per-TFM floors and why
+  they exist, so the reason net8 consumers are supported is written down rather than
+  implied by the csproj. Documentation only — no code or packaging change.
+
 ## [0.7.1] — 2026-07-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/NextIteration.SpectreConsole.Auth.svg)](https://www.nuget.org/packages/NextIteration.SpectreConsole.Auth/)
 [![Downloads](https://img.shields.io/nuget/dt/NextIteration.SpectreConsole.Auth.svg)](https://www.nuget.org/packages/NextIteration.SpectreConsole.Auth/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![.NET](https://img.shields.io/badge/.NET-10.0-purple.svg)](https://dotnet.microsoft.com/)
+[![.NET](https://img.shields.io/badge/.NET-8.0%20%7C%2010.0-purple.svg)](https://dotnet.microsoft.com/)
 [![CI](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/actions/workflows/ci.yml/badge.svg)](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/actions/workflows/ci.yml)
 
 Encrypted credential storage and ready-made `accounts` commands for CLI tools built on [Spectre.Console](https://spectreconsole.net/).
@@ -39,7 +39,7 @@ dotnet add package NextIteration.SpectreConsole.Auth.Providers.Airtable
 dotnet add package NextIteration.SpectreConsole.Auth.Providers.SoftwareOne
 ```
 
-Targets `net10.0`.
+Targets `net8.0` and `net10.0`.
 
 ---
 
@@ -338,9 +338,13 @@ Implement `ICredentialEncryption` and register it before calling `AddCredentialS
 
 ## Requirements
 
-- **.NET 10.0** or later
-- **Spectre.Console** 0.54+ and **Spectre.Console.Cli** 0.53+
-- **Microsoft.Extensions.DependencyInjection.Abstractions** 10.0+
+- **.NET 8.0** or **.NET 10.0** (the package multi-targets `net8.0;net10.0`)
+- **Spectre.Console** 0.57.2+ and **Spectre.Console.Cli** 0.55.0+
+- **Microsoft.Extensions.DependencyInjection.Abstractions** — 8.0.2+ on `net8.0`,
+  10.0.10+ on `net10.0`
+
+Dependency floors are set per target framework, so a `net8.0` consumer is never dragged
+off its own 8.0.x servicing line.
 
 Everything else is transitive.
 


### PR DESCRIPTION
## What changed

The README claimed `net10.0` only — in the .NET badge, the install section, and Requirements — even though the package has multi-targeted `net8.0;net10.0` since 0.7.0.

| Claim before | Reality in csproj | Now |
|---|---|---|
| badge `.NET-10.0` | `net8.0;net10.0` | `.NET-8.0 \| 10.0` |
| "Targets `net10.0`." | same | "Targets `net8.0` and `net10.0`." |
| "**.NET 10.0** or later" | same | ".NET 8.0 or .NET 10.0" |
| Spectre.Console 0.54+ / .Cli 0.53+ | 0.57.2 / 0.55.0 | 0.57.2+ / 0.55.0+ |
| DI.Abstractions "10.0+" | net8 → 8.0.2, net10 → 10.0.10 | per-TFM floors |

## Why

The README was turning away the net8 LTS audience that 0.7.1 went out of its way to support with per-TFM dependency floors. Every claim is now checked against the csproj rather than written from memory.

Requirements also gains one sentence on *why* the floors are per-TFM: a `PackageReference` version in a library is a minimum NuGet forces on every consumer, so a single high floor would drag net8 consumers off their own servicing line. That was the whole point of 0.7.1 and appeared nowhere in the docs — which is how the README drifted from the build in the first place.

## Checklist

- [x] Build is clean — no new warnings
- [x] Tests pass — 145/145 (unchanged; docs-only)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Dependency floors unchanged

## Consumer impact

None. Documentation only. The README ships as a packaged asset via `PackageReadmeFile`, so `dotnet build -c Release` was re-run to confirm packing still succeeds at zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)