### PR TITLE
chore: adopt the standard CI shape and test net8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,81 @@
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # NuGet packages (src + tests)
+  #
+  # Minor and patch bumps are grouped into a single PR so the auto-merge
+  # workflow has one unambiguous update-type to act on. Major bumps are
+  # deliberately left OUT of the group, so each arrives as its own PR and
+  # stays open for manual review.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - dependencies
+      - nuget
+    # -------------------------------------------------------------------------
+    # These three carry deliberate per-TFM floors (see the csproj comment): a
+    # net8.0 consumer must stay on its own 8.0.x servicing line, so an
+    # 8.x -> 10.x major PR is never mergeable and would just be weekly noise.
+    #
+    # Two caveats, both inherent to Dependabot rather than to this repo:
+    #  1. `ignore` matches by dependency NAME and cannot be scoped to a single
+    #     target framework. These packages are referenced under BOTH the net8.0
+    #     and net10.0 ItemGroups, so this also suppresses a future net10 major
+    #     (10.x -> 11.x). Bump those by hand when a new .NET major lands.
+    #  2. `ignore` conditions filter SECURITY updates as well as version
+    #     updates, so a major-version security fix for these would also be
+    #     suppressed. Low risk in practice (a CVE fix for 8.0.x ships as
+    #     8.0.y, a patch), but worth knowing.
+    # -------------------------------------------------------------------------
+    ignore:
+      - dependency-name: Microsoft.Extensions.DependencyInjection.Abstractions
+        update-types:
+          - version-update:semver-major
+      - dependency-name: Microsoft.Extensions.Http
+        update-types:
+          - version-update:semver-major
+      - dependency-name: System.Security.Cryptography.ProtectedData
+        update-types:
+          - version-update:semver-major
+    groups:
+      nuget-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions used by ci.yml (checkout, setup-dotnet, upload/download
+  # artifact, NuGet/login). Same grouping rule as NuGet.
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(actions)"
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,97 @@
+# CI for NextIteration.SpectreConsole.Auth.
+# Canonical shape defined in NextIteration.Standards STANDARD.md section 3 — change it
+# there first, then here.
+#
+# The single required status check is `ci`, the aggregating gate below. `build` and `test`
+# must NOT be required directly: `test` is a matrix, so its check names carry the matrix
+# values and change whenever the matrix does. The gate's name is stable.
+#
+# This repo runs the test matrix on macOS as well as Linux, and installs
+# gnome-keyring-daemon on the Linux leg. Both are recorded in EXCEPTIONS.md: it is the
+# only repo with OS-native Keychain and libsecret backends.
 name: CI
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   push:
     branches: [ main ]
-    tags:
-      - 'v*'
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
+
+# Superseded pushes are cancelled. Tag builds are never cancelled — a half-cancelled
+# release can leave an incomplete package set on nuget.org.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 15
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+      # Both SDKs: shipping projects target net8.0 and net10.0 and the tests run
+      # against BOTH (STANDARD.md 2.3), which needs the 8.0 runtime present.
+      - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
-      # The libsecret backend exercises the Secret Service D-Bus API
-      # which isn't running by default on ubuntu-latest. Install and start
-      # gnome-keyring-daemon so LibsecretCredentialManagerTests actually
-      # hit libsecret instead of short-circuiting via the
-      # "secret-service-unavailable" probe.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack --configuration Release --no-build --output ./artifacts
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget-package
+          # Both .nupkg and .snupkg, so the publish job's glob also pushes symbols.
+          path: ./artifacts/*nupkg
+
+  test:
+    strategy:
+      fail-fast: false        # one platform failing must not hide another's result
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/Directory.Packages.props', '**/*.csproj') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      # The libsecret backend exercises the Secret Service D-Bus API, which is not
+      # running on a bare ubuntu runner. Without this the tests short-circuit through
+      # the "secret-service-unavailable" probe instead of hitting libsecret. Linux-only;
+      # the macOS leg uses Security.framework and needs nothing.
       - name: Install and start gnome-keyring-daemon
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y gnome-keyring dbus-x11 libsecret-1-0 libsecret-1-dev
@@ -40,86 +102,65 @@ jobs:
           gnome-keyring-daemon --start --components=secrets &
           sleep 2
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-
+      # Tests run across every shipped TFM (STANDARD.md 2.3). No --no-build: this job
+      # does not share a filesystem with `build`, and rebuilding is cheaper and less
+      # fragile than shipping obj/ between jobs.
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+        run: dotnet test --configuration Release --verbosity normal
 
-      - name: Pack
-        run: dotnet pack --configuration Release --no-build --output ./artifacts
-
-      - name: Upload package artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: nuget-package
-          # Capture both .nupkg and .snupkg so the publish job's
-          # `dotnet nuget push *.nupkg` can also push the matching
-          # symbol package next to it.
-          path: ./artifacts/*nupkg
-
-  # Keychain backend is macOS-only. This job runs the same test suite on a
-  # real macOS runner so the Keychain tests actually exercise
-  # Security.framework (on Linux/Windows they vacuously pass via the
-  # OperatingSystem.IsMacOS early-return guard). Runs in parallel with the
-  # primary build job.
-  test-macos:
-    runs-on: macos-latest
-
+  # THE required status check. Aggregates everything above so the ruleset never has to
+  # know the matrix shape. `if: always()` is essential — without it the gate is skipped
+  # when a dependency fails, and a skipped check reads as success to branch protection.
+  ci:
+    needs: [ build, test ]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-
-      - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal
+      - name: Verify every required job succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "upstream results: $RESULTS"
+          case "$RESULTS" in
+            *failure*|*cancelled*|*skipped*)
+              echo "::error title=CI gate::an upstream job did not succeed ($RESULTS)"
+              exit 1 ;;
+          esac
+          echo "all upstream jobs succeeded"
 
   publish:
-    needs: build
+    needs: ci
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 15
+    if: startsWith(github.ref, 'refs/tags/')
 
     permissions:
-      id-token: write   # enable GitHub OIDC token issuance for NuGet trusted publishing
+      id-token: write   # GitHub OIDC token issuance for NuGet trusted publishing
       contents: read
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup .NET 10
-        uses: actions/setup-dotnet@v5
+      - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
-      - name: Download artifact
-        uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: nuget-package
           path: ./artifacts
 
-      # Exchange the GitHub OIDC token for a short-lived (1 hour) nuget.org
-      # API key. Requires a Trusted Publishing policy on nuget.org bound to
-      # this repo + workflow file (ci.yml). NUGET_USER is the nuget.org
-      # account/profile name (not an email).
-      - name: NuGet login (OIDC → temporary API key)
+      # Exchanges the OIDC token for a short-lived (1h) nuget.org key. Requires a
+      # Trusted Publishing policy on nuget.org bound to this repo + workflow file.
+      # NUGET_USER is the nuget.org account name, not an email.
+      - name: NuGet login (OIDC to temporary API key)
         uses: NuGet/login@v1
         id: login
         with:
           user: ${{ secrets.NUGET_USER }}
 
       - name: Publish to NuGet
-        run: dotnet nuget push "./artifacts/*.nupkg" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: >
+          dotnet nuget push "./artifacts/*.nupkg"
+          --api-key "${{ steps.login.outputs.NUGET_API_KEY }}"
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+# CodeQL code scanning. See STANDARD.md section 4.4.
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Weekly, so a newly published query pack finds existing code even when
+    # nothing has been pushed. Offset off the hour to avoid the scheduling spike.
+    - cron: '37 4 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      security-events: write   # required to upload results
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: csharp
+          # security-and-quality is broader than the default security-extended;
+          # these are small libraries, so the extra findings are affordable.
+          queries: security-and-quality
+
+      # Explicit build rather than autobuild: these repos multi-target, and
+      # autobuild has picked a single TFM in the past, silently analysing half
+      # the code. Restore is separate so a restore failure is legible.
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,80 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot minor and patch bumps once CI passes. Major bumps are
+# left untouched so they stay open for manual review.
+#
+# `on: pull_request` (not pull_request_target) is deliberate: pull_request_target
+# would run with a write token in the base-repo context, which is the classic
+# privilege-escalation footgun. On Dependabot pull_request events the GITHUB_TOKEN
+# is read-only by default, and the `permissions:` block below grants the write
+# scopes back. This is GitHub's documented recipe.
+#
+# ---------------------------------------------------------------------------
+# REQUIRED SETUP: the `AUTO_MERGE_PAT` secret must be stored as a
+# **Dependabot secret**, NOT an Actions secret:
+#
+#   Settings -> Secrets and variables -> Dependabot -> New repository secret
+#   gh secret set AUTO_MERGE_PAT --app dependabot
+#
+# Workflows triggered by Dependabot events only receive Dependabot secrets;
+# Actions secrets resolve to an empty string. The guard step below fails loudly
+# if that happens rather than letting the approval silently no-op.
+#
+# The PAT must belong to a CODEOWNER (the main ruleset sets
+# require_code_owner_review: true, and a GITHUB_TOKEN/bot approval cannot
+# satisfy a code-owner review). Scope: fine-grained with
+# "Pull requests: read and write" on this repo, or classic `repo`.
+# ---------------------------------------------------------------------------
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+    steps:
+      - name: Verify AUTO_MERGE_PAT is present
+        env:
+          AUTO_MERGE_PAT: ${{ secrets.AUTO_MERGE_PAT }}
+        run: |
+          if [ -z "$AUTO_MERGE_PAT" ]; then
+            echo "::error title=Missing AUTO_MERGE_PAT::Store it as a *Dependabot* secret (gh secret set AUTO_MERGE_PAT --app dependabot). Actions secrets are not available to Dependabot-triggered workflows."
+            exit 1
+          fi
+
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # `--auto` does NOT merge immediately: it queues the merge behind the branch
+      # ruleset, so the required CI checks (build, test-macos) must go green first.
+      # If CI fails, the PR just stays open.
+      #
+      # The approval uses the PAT so it counts as a code-owner review. Because the
+      # ruleset also sets dismiss_stale_reviews_on_push and require_last_push_approval,
+      # a follow-up Dependabot force-push re-triggers this workflow (pull_request
+      # includes `synchronize`) and the PR is re-approved.
+      - name: Approve and enable auto-merge (minor + patch)
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+          steps.meta.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+
+      # No approval, no auto-merge — the PR stays open for a human.
+      - name: Leave major bumps open
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        env:
+          DEPS: ${{ steps.meta.outputs.dependency-names }}
+        run: |
+          echo "::notice title=Major version bump::${DEPS} is a major bump; leaving this PR open for manual review."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI adopts the shared NextIteration.Standards shape.** The single required status check
+  is now `ci`, an aggregating gate over `build` and `test` that does no work itself. The
+  previous `build` + `test-macos` jobs became a `build` job (restore/build/pack) and a
+  `test` matrix over `ubuntu-latest` and `macos-latest`; the `gnome-keyring-daemon` setup
+  is now a step guarded on `runner.os == 'Linux'`. Gating on a gate rather than on job
+  names means the matrix can change without touching branch protection — a required check
+  that names a matrix leg breaks the moment the matrix is edited. Also adds
+  `concurrency` with `cancel-in-progress` (tag builds excepted, so a release cannot be
+  half-cancelled), `timeout-minutes` on every job, and NuGet restore caching.
+- **Added CodeQL code scanning** (`security-and-quality` queries) with an explicit build
+  rather than autobuild, so both target frameworks are analysed.
+- **Added Dependabot** with minor and patch updates grouped into a single PR and
+  auto-merged behind CI; major updates arrive individually and stay open for review. The
+  three packages carrying deliberate per-TFM floors have major updates suppressed outright,
+  because an 8.x to 10.x bump there is never mergeable by design.
 - **Migrated the test suite from xUnit.net v2 to v3.** `xunit` `2.9.3` was
   flagged deprecated ("Legacy") on NuGet and `2.9.3` is the terminal v2 release,
   so no further fixes were coming. Replaced it with `xunit.v3` `4.0.0`. Note the
@@ -44,6 +59,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the latest stable releases of each. No public API change.
 
 ### Fixed
+
+- **The `net8.0` target is now actually tested.** The package has multi-targeted
+  `net8.0;net10.0` since 0.7.0, but the test project targeted `net10.0` only and CI
+  installed just the 10.0.x SDK — so the framework whose consumers the per-TFM dependency
+  floors exist to protect was shipped unverified. The test project now targets both, and
+  CI installs both SDKs. The suite goes from 145 to 290 tests (145 per framework) and
+  passes on both; no behavioural difference was found, so this closes a verification gap
+  rather than a bug.
 
 - **README now states the supported target frameworks accurately.** It claimed `net10.0`
   only — in the .NET badge, the install section, and Requirements — even though the package

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net10.0</TargetFramework>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<!-- xUnit.net v3 test projects must be executable; the runner
 		     generates the entry point. -->
 		<OutputType>Exe</OutputType>


### PR DESCRIPTION
## What changed

Brings this repo onto the [NextIteration.Standards](https://github.com/StuartMeeks/NextIteration.Standards) baseline for CI, and closes the one **correctness** finding from the alignment audit.

**`net8.0` was shipped untested.** The package has multi-targeted `net8.0;net10.0` since 0.7.0, but the test project targeted `net10.0` only and CI installed just the `10.0.x` SDK — so the framework whose consumers 0.7.1's per-TFM dependency floors exist to protect was never exercised. Now both are tested: **145 tests → 290**, and `net8.0` passes with no behavioural difference. A verification gap, not a bug — but it made the entire floor design unverifiable.

**CI adopts the canonical shape.**

| | before | after |
|---|---|---|
| jobs | `build`, `test-macos`, `publish` | `build`, `test` (matrix), `ci`, `publish` |
| required check | `build` + `test-macos` | **`ci`** (aggregating gate) |
| SDKs installed | `10.0.x` | `8.0.x` + `10.0.x` |
| concurrency / timeouts / cache | none | all three |

The required check becomes `ci`, a gate that does no work and just aggregates `build` and `test`. `build` and `test` must never be required directly: `test` is a matrix, so its check names carry the matrix values and change whenever the matrix does — and this is the only repo whose matrix includes macOS. Gating on the gate means the matrix can change without ever touching branch protection again.

The old `test-macos` job becomes the `macos-latest` leg of that matrix, and the `gnome-keyring-daemon` setup becomes a step guarded on `runner.os == 'Linux'`. Both remain documented exceptions in `EXCEPTIONS.md`; only the mechanism changed.

**Adds CodeQL** with an explicit build rather than autobuild, so both frameworks are analysed rather than whichever one autobuild picks.

**Adds Dependabot** — minor/patch grouped into one PR and auto-merged behind CI, majors individually and left open. The three packages with deliberate per-TFM floors have majors suppressed outright: an 8.x → 10.x bump there is never mergeable, and SelfUpdate has already had to close exactly that PR.

## Merge order — please read

This PR **adds** the `ci` job, so it reports a `ci` check itself. The ruleset's required check must be switched from `build`/`test-macos` to `ci` **before this can merge**, because `test-macos` no longer exists and would never report:

```
cd NextIteration.Standards
./scripts/apply-repo-settings.sh --repo NextIteration.SpectreConsole.Auth --with-required-checks
```

## Checklist

- [x] Build is clean — zero warnings, both frameworks
- [x] Tests pass on every shipped target framework — 290/290 locally
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Dependency floors unchanged

## Consumer impact

None. No shipping code, no packaging, no dependency change. The test project is `IsPackable=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)