### PR TITLE
chore: adopt the standards baseline docs and config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -59,6 +59,12 @@ dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_with_u
 
 dotnet_naming_symbols.private_fields.applicable_kinds = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+# A const IS a field, so without this the rule demands `_nonceSize` for
+# `private const int NonceSize` — PascalCase constants are correct .NET style and
+# the codebase uses them throughout. Restricting the rule to instance fields keeps
+# it aimed at what it was written for. Found when EnforceCodeStyleInBuild surfaced
+# 76 IDE1006 violations, every one of them a constant.
+dotnet_naming_symbols.private_fields.required_modifiers =
 
 dotnet_naming_style.camel_case_with_underscore.capitalization = camel_case
 dotnet_naming_style.camel_case_with_underscore.required_prefix = _

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## What changed
+
+<!-- One or two sentences. What a reader of the changelog needs to know. -->
+
+## Why
+
+<!-- The motivating problem. Link an issue if there is one. -->
+
+## Checklist
+
+- [ ] Build is clean — no new warnings (`TreatWarningsAsErrors` is on)
+- [ ] Tests pass on **every** shipped target framework
+- [ ] Public API changes carry XML docs
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] Dependency floors unchanged, or the consumer impact is described below
+
+## Consumer impact
+
+<!-- Delete if none. Note any raised dependency floor, changed public signature,
+     new target framework, or on-disk format change - including whether existing
+     stored data stays readable. -->

--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,16 @@ PublishScripts/
 *.nupkg
 # NuGet Symbol Packages
 *.snupkg
+# Stray "C:/" / "c:/" directory created on non-Windows when the csproj's
+# Windows-style PackageOutputPath is interpreted as a relative path.
+**/[Cc]:/
+
+# Per-user Claude Code state — never commit
+.claude/settings.local.json
+.claude/projects/
+
+# Pack output (matches CI's --output flag)
+artifacts/
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
 # except build/, which is used as an MSBuild target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Repository baseline files adopted from NextIteration.Standards.** Adds `SECURITY.md`
+  (disclosure policy, and an explicit statement of what `LocalFileCredentialEncryption`
+  does *not* protect against), `CONTRIBUTING.md`, a pull request template, and a
+  `CLAUDE.md` carrying the constraints an agent would otherwise violate. `global.json` now
+  pins the SDK feature band with `rollForward` as well as selecting the test runner, so a
+  contributor on an older SDK gets the same analyzer results as CI rather than a build that
+  fails only for them. `.gitignore` and `.editorconfig` move to the canonical copies — the
+  `.editorconfig` change fixes a naming rule that matched `const` fields and demanded
+  `_nonceSize` for `private const int NonceSize`. No shipping code or packaging change.
 - **CI adopts the shared NextIteration.Standards shape.** The single required status check
   is now `ci`, an aggregating gate over `build` and `test` that does no work itself. The
   previous `build` + `test-macos` jobs became a `build` job (restore/build/pack) and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md — NextIteration.SpectreConsole.Auth
+
+## This package
+
+Encrypted credential storage plus a ready-made `accounts` command branch for CLI tools
+built on Spectre.Console. Consumers register a credential store and one or more auth
+providers, then get `accounts add/list/select/delete` wired into their existing
+`CommandApp`. Storage backends are pluggable: an AES-GCM local file by default, or the
+OS-native stores — macOS Keychain, Linux libsecret, Windows DPAPI.
+
+The provider packages in `NextIteration.SpectreConsole.Auth.Providers` consume this one
+through a capped range (`[0.7.1,1.0.0)`), so a breaking change to `ICredentialCollector`
+or `ICredentialSummaryProvider` is a downstream event, not a local one.
+
+## Things that are easy to get wrong here
+
+- **Per-TFM dependency floors are deliberate.** `Microsoft.Extensions.*` and
+  `System.Security.Cryptography.ProtectedData` are floored at 8.0.x for `net8.0` and
+  10.0.x for `net10.0`. Raising the net8 floor to a 10.x version drags every net8 LTS
+  consumer off its own servicing line. Dependabot is configured to never propose it; do
+  not do it by hand either.
+- **The test matrix runs Linux, Windows and macOS because each has a real backend** —
+  libsecret, DPAPI plus ACL hardening, and Keychain respectively. Platform-guarded tests
+  pass vacuously off their platform, so dropping a leg silently stops testing a shipped
+  code path. This is not theoretical: adding the Windows leg immediately found a
+  concurrency bug in `AtomicFile`.
+- **Atomic replace is not the same call on every platform.** POSIX uses `File.Move` with
+  overwrite (`rename(2)`); Windows must use `File.Replace` (`ReplaceFile`), because
+  `MoveFileEx` raises a sharing violation when the destination is open or two replacements
+  race. See the remarks on `AtomicFile`.
+- **`LocalFileCredentialEncryption`'s security boundary is filesystem permissions**, not
+  the KEK — it is derived from non-secret machine identifiers unless the caller supplies
+  `AdditionalEntropy`. Do not describe it as protecting against same-user code.
+
+## Repository baseline
+
+This repo conforms to
+[NextIteration.Standards](https://github.com/StuartMeeks/NextIteration.Standards).
+Build properties, test stack, CI shape, and branch protection are defined there, not
+here. Before changing any of those, read `STANDARD.md`; if this repo needs to deviate,
+that is an `EXCEPTIONS.md` entry in the standards repo, not a local difference.
+
+## Non-negotiables
+
+- **The build must be clean.** `TreatWarningsAsErrors` is on and analyzers run at
+  `latest`. A warning is a build failure.
+- **Tests must pass on every shipped target framework** (`net8.0` and `net10.0`). A change
+  that only passes on one is not finished. Shipping a target you do not test is a defect,
+  not a scoping decision.
+- **Dependency floors are deliberate and per-TFM.** A `PackageReference` version in a
+  library is a *minimum* NuGet forces on every consumer, so raising a floor is a
+  consumer-visible change even when nothing in the code needs it. Never raise one to
+  silence a warning.
+- **Public API changes need XML docs.** `GenerateDocumentationFile` is on and the public
+  surface is fully documented.
+- **Update `CHANGELOG.md`** under `[Unreleased]`, saying what changed and why.
+
+## Dependabot
+
+Minor and patch updates auto-merge behind CI. Major updates stay open for a human — that
+is deliberate, not a backlog to clear. Packages with per-TFM floors have major updates
+suppressed entirely via `ignore`; bump those by hand when a new .NET major lands.
+
+## After opening a pull request
+
+Watch CI to completion, report the real check results, then **offer to merge** in the same
+message. Do not stop silently and wait to be asked.
+
+- If branch protection blocks the merge, say so and offer `gh pr merge --admin`. These
+  repos require a code-owner review only the maintainer can give, which is why `--admin` is
+  the tool — but that mechanic is not the reason the offer is wanted. The reason is simply
+  that the maintainer has grown comfortable delegating this to an agent, so treat the
+  latest instruction as authoritative over this file.
+- **Merge only on an explicit yes.** The offer is pre-approved; the action is not.
+- Never offer while checks are failing or still running. Report that state instead.
+- Report the checks that actually ran. A skipped check is not a passing check, and branch
+  protection treats them differently from how they read in a summary.
+
+## CI
+
+The single required status check is `ci` — an aggregating gate over `build` and `test`.
+Renaming those jobs is safe; the ruleset never names them. Do not make them required
+checks directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Issues and pull requests are welcome.
+
+## Before you open a PR
+
+- **The build must be clean.** `TreatWarningsAsErrors` is on and analyzers run at
+  `latest`. A warning is a build failure, not a suggestion.
+- **Tests run on every target framework** the project ships. `dotnet test` covers
+  `net8.0` and `net10.0`; a change that only passes on one is not finished.
+- **Public API changes need XML docs.** `GenerateDocumentationFile` is on and the
+  public surface is fully documented — keep it that way.
+- **Update `CHANGELOG.md`.** Keep a Changelog format, under `[Unreleased]`. Say what
+  changed and why; "bump dependency" without a reason is not useful six months later.
+
+## Dependency changes
+
+Dependency floors are deliberate and per target framework. A `PackageReference`
+version in a library is a *minimum* NuGet forces on every consumer, so raising a
+floor is a consumer-visible change even when nothing in the code needs it. Read
+`STANDARD.md` sections 1.4 and 1.5 in `NextIteration.Standards` before changing one.
+
+Minor and patch bumps arrive automatically via Dependabot and merge behind CI.
+Major bumps stay open for a human — that is deliberate, not a backlog.
+
+## Repository conventions
+
+These repositories share a baseline defined in
+[NextIteration.Standards](https://github.com/StuartMeeks/NextIteration.Standards):
+build properties, test stack, CI shape, and branch protection. If a change would
+deviate from it, raise that there first — a per-repo exception is a documented
+entry, not a quiet difference.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub's **Report a vulnerability** button under this
+repository's Security tab, which opens a private advisory visible only to the
+maintainers. Please do not open a public issue for a suspected vulnerability.
+
+Include the affected package and version, what an attacker can achieve, and a
+reproduction if you have one.
+
+You can expect an acknowledgement within 7 days, an assessment within 14, and
+credit in the advisory and changelog unless you ask otherwise.
+
+## Supported versions
+
+Only the latest released minor of each package receives security fixes. These are
+pre-1.0 libraries and there are no long-term support branches.
+
+## Scope
+
+These libraries store credentials on the local filesystem or in an OS secret store.
+Two things are explicitly **not** claimed:
+
+- `LocalFileCredentialEncryption` derives its key-encryption key from non-secret
+  machine and user identifiers. Its real security boundary is filesystem permissions.
+  It protects credentials at rest against another *user*; it does not protect them
+  against code running as the same user. Supply `AdditionalEntropy` for a KEK that
+  depends on a caller-held secret as well as the machine.
+- Nothing here defends against a compromised host, a debugger attached to the
+  process, or a heap dump taken while credentials are decrypted in memory.
+
+Reports demonstrating a break *within* those stated boundaries are in scope and
+welcome. Reports that only restate a documented limitation are not vulnerabilities.

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }


### PR DESCRIPTION
## What changed

The non-CI half of the [NextIteration.Standards](https://github.com/StuartMeeks/NextIteration.Standards) baseline.

| File | Clause | Note |
|---|---|---|
| `SECURITY.md` | §4.11 | Disclosure policy + explicit scope |
| `CONTRIBUTING.md` | §5.4 | |
| `.github/PULL_REQUEST_TEMPLATE.md` | §5.4 | |
| `CLAUDE.md` | §5.7 | Constraints an agent would otherwise violate |
| `global.json` | §1.9 | Now pins the SDK band + `rollForward`, not just the runner |
| `.gitignore` | §5.2 | Canonical copy |
| `.editorconfig` | §5.2 | Canonical copy — **contains a real fix**, see below |

**`SECURITY.md` states the threat model, not just an address.** `LocalFileCredentialEncryption`'s boundary is filesystem permissions, not the KEK — which is derived from non-secret machine identifiers unless the caller supplies `AdditionalEntropy`. A credential library without that written down invites reports that are really restatements of documented limitations.

**`global.json` was letting the SDK float.** With `TreatWarningsAsErrors` on, a contributor on an older SDK can get different analyzer results from CI — a build that fails only for them. Now pinned to the feature band with `rollForward`.

**The `.editorconfig` change is a fix, not a sync.** The private-field naming rule set `applicable_kinds = field`, and a `const` *is* a field, so it demanded `_nonceSize` for `private const int NonceSize`. Scoped to instance fields via `required_modifiers`.

## What is deliberately NOT here

`EnforceCodeStyleInBuild` (§1.2.1). Enabling it produces **490 build errors** in this repo — 252 of them IDE0011 wanting braces on guard clauses this codebase deliberately writes without them, plus IDE0058/IDE0046 opinionated refactors. The `.editorconfig` marks these advisory (`suggestion`/`warning`); `TreatWarningsAsErrors` turns them all into hard failures. The clause is now `SHOULD` and explicitly blocked in the standard pending a per-rule gate-versus-advisory decision. Rewriting 490 sites in a credential library to satisfy unvalidated preferences is not conformance.

## Checklist

- [x] Build is clean — zero warnings
- [x] Tests pass on every shipped target framework — 290/290
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Dependency floors unchanged

## Consumer impact

None. No shipping code, no packaging change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)