### PR TITLE
chore: adopt Central Package Management and collect coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,20 @@ jobs:
       # Tests run across every shipped TFM (STANDARD.md 2.3). No --no-build: this job
       # does not share a filesystem with `build`, and rebuilding is cheaper and less
       # fragile than shipping obj/ between jobs.
+      # `-- --coverage` passes through to Microsoft.Testing.Platform's coverage
+      # extension (STANDARD.md 2.6). Referencing a collector without invoking it is
+      # worse than none: it reads as coverage in the dependency list while producing
+      # no data, which is exactly what coverlet was doing in a sibling repo.
       - name: Test
-        run: dotnet test --configuration Release --verbosity normal
+        run: dotnet test --configuration Release --verbosity normal -- --coverage
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ matrix.os }}
+          path: '**/TestResults/*.coverage'
+          if-no-files-found: warn
 
   # THE required status check. Aggregates everything above so the ruleset never has to
   # know the matrix shape. `if: always()` is essential — without it the gate is skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Central Package Management adopted.** Versions move from the two project files to a
+  root `Directory.Packages.props`, with `CentralPackageVersionOverrideEnabled=false` so a
+  stray inline `Version=` is a hard build error rather than being silently ignored. The
+  per-TFM floors are preserved exactly — CPM re-evaluates the conditional `ItemGroup`s per
+  target framework during the inner build, so `net8.0` still floors at 8.0.x and `net10.0`
+  at 10.0.x. **Verified behaviour-preserving: the generated `.nuspec` is byte-identical
+  before and after.** Raising a floor is a consumer-visible change and deliberately not
+  bundled here.
+- **Properties every project restated now live in `Directory.Build.props`.** `ImplicitUsings`,
+  `AnalysisLevel`, `GenerateDocumentationFile`, `EnablePackageValidation`, `IncludeSymbols`,
+  `SymbolPackageFormat`, `DebugType`, `PublishRepositoryUrl`, `EmbedUntrackedSources`,
+  `ContinuousIntegrationBuild`, `SatelliteResourceLanguages`, `PackageLicenseExpression` and
+  `Copyright`. Duplicated settings are how the repos drifted apart in the first place; each
+  csproj now carries only what is genuinely specific to it.
+- **Code coverage is now collected.** Adds `Microsoft.Testing.Extensions.CodeCoverage` and,
+  crucially, has CI invoke it (`dotnet test -- --coverage`) and upload the result. A
+  collector that is referenced but never invoked reads as coverage while producing no data.
 - **Repository baseline files adopted from NextIteration.Standards.** Adds `SECURITY.md`
   (disclosure policy, and an explicit statement of what `LocalFileCredentialEncryption`
   does *not* protect against), `CONTRIBUTING.md`, a pull request template, and a

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,19 @@
 <Project>
   <PropertyGroup>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>© Stuart Meeks</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Authors>Stuart Meeks</Authors>
     <Company>Next Iteration</Company>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,72 @@
+<Project>
+
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<!--
+			Hard-fail if a csproj declares <PackageReference Version="…" />
+			alongside CPM. Without this MSBuild silently ignores the inline
+			version and uses the central one — which is the exact drift this
+			file exists to prevent. STANDARD.md 1.3.
+		-->
+		<CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+	</PropertyGroup>
+
+	<!--
+		Runtime-aligned Microsoft platform deps: per-TFM floors. STANDARD.md 1.4.
+
+		In a library a PackageReference version is a *minimum* NuGet forces on
+		every downstream consumer (lowest-applicable-version resolution). Flooring
+		these at a single high major would drag net8 LTS consumers off their own
+		runtime-aligned servicing line onto the net10 one. Each target framework
+		therefore floors at its own major. CPM re-evaluates these conditional
+		groups per-TFM during the inner build.
+
+		These three are also listed under `ignore` in .github/dependabot.yml with
+		update-types: [version-update:semver-major] (STANDARD.md 4.10), so
+		Dependabot never proposes the 8.x -> 10.x bump that can never be merged.
+
+		Versions here are unchanged from the per-project references they replaced.
+		This migration is deliberately behaviour-preserving: raising a floor is a
+		consumer-visible change and belongs in its own reviewed commit.
+	-->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+		<PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+		<PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+		<PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
+	</ItemGroup>
+
+	<!--
+		Not runtime-aligned: a single common floor at the version actually built
+		and tested against. Spectre.Console is pre-1.0 — breaking changes land
+		between minors, so a low floor would be both meaningless and risky.
+		STANDARD.md 1.5.
+
+		Spectre.Console.Cli's latest stable is 0.55.0 (no 0.56/0.57 exists); it
+		requires Spectre.Console >= 0.55.0, which 0.57.2 satisfies.
+	-->
+	<ItemGroup>
+		<PackageVersion Include="Spectre.Console" Version="0.57.2" />
+		<PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+	</ItemGroup>
+
+	<!-- Build / source-link tooling. PrivateAssets="All" in the csproj. STANDARD.md 1.7. -->
+	<ItemGroup>
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
+	</ItemGroup>
+
+	<!--
+		Test-only. STANDARD.md 2.1/2.5/2.6 — xunit.v3 on Microsoft.Testing.Platform.
+		Do NOT add Microsoft.NET.Test.Sdk, xunit.runner.visualstudio or
+		coverlet.collector: all three are VSTest-only and MTP replaces the runner.
+	-->
+	<ItemGroup>
+		<PackageVersion Include="xunit.v3" Version="4.0.0" />
+		<PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+	</ItemGroup>
+
+</Project>

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -1,12 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AnalysisLevel>latest</AnalysisLevel>
 		<!--
 			LibraryImport source generator emits unsafe blocks for the
 			Keychain P/Invoke layer. The unsafe code stays entirely within
@@ -18,26 +13,16 @@
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
 		<Version>0.7.1</Version>
-		<Authors>Stuart Meeks</Authors>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
 		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\packages</PackageOutputPath>
 		<IncludeBuildOutput>true</IncludeBuildOutput>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>spectre;cli;authentication;credentials;encryption</PackageTags>
 		<PackageIcon>icon.png</PackageIcon>
-		<Copyright>© Stuart Meeks</Copyright>
-		<EnablePackageValidation>true</EnablePackageValidation>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<DebugType>portable</DebugType>
-		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -46,9 +31,9 @@
 
 	<ItemGroup>
 		<!-- Common to all target frameworks. -->
-		<PackageReference Include="Spectre.Console" Version="0.57.2" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" PrivateAssets="All" />
+		<PackageReference Include="Spectre.Console" />
+		<PackageReference Include="Spectre.Console.Cli" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 		<None Include="icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
@@ -61,15 +46,15 @@
 		aligned major: net8 -> 8.0.x, net10 -> 10.0.x.
 	-->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />
-		<PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Http" />
+		<PackageReference Include="System.Security.Cryptography.ProtectedData" />
 	</ItemGroup>
 
 </Project>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -5,8 +5,6 @@
 		<!-- xUnit.net v3 test projects must be executable; the runner
 		     generates the entry point. -->
 		<OutputType>Exe</OutputType>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -25,7 +23,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit.v3" Version="4.0.0" />
+		<PackageReference Include="xunit.v3" />
+		<!-- STANDARD.md 2.6: MTP coverage collector. CI passes the coverage flag. -->
+		<PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## What changed

**Central Package Management** (§1.3). Versions move to a root `Directory.Packages.props` with `CentralPackageVersionOverrideEnabled=false`, so a stray inline `Version=` is a hard build error rather than silently ignored.

The per-TFM floors survive intact — CPM re-evaluates the conditional `ItemGroup`s per target framework during the inner build, so `net8.0` still floors at 8.0.2/8.0.1/8.0.0 and `net10.0` at 10.0.10. **Versions are copied across unchanged.** Raising a floor is consumer-visible and belongs in its own reviewed commit, not smuggled into a mechanical migration.

> **Verified behaviour-preserving.** Packed before and after and diffed: the generated `.nuspec` is **byte-identical**, and the only difference anywhere in the package is the `.psmdcp` filename, which NuGet regenerates on every pack.

**Thinner csprojs** (§1.2). `Directory.Build.props` absorbs the fourteen properties both projects restated: `ImplicitUsings`, `AnalysisLevel`, `GenerateDocumentationFile`, `EnablePackageValidation`, `IncludeSymbols`, `SymbolPackageFormat`, `DebugType`, `PublishRepositoryUrl`, `EmbedUntrackedSources`, `ContinuousIntegrationBuild`, `SatelliteResourceLanguages`, `PackageLicenseExpression`, `Copyright`, `Authors`. That duplication is the mechanism by which these repos drifted — fourteen copies are fourteen chances to diverge. Each csproj now carries only what is specific to it, including the genuine exception `AllowUnsafeBlocks`.

**Coverage is now collected** (§2.6). Adds `Microsoft.Testing.Extensions.CodeCoverage` *and* has CI invoke it (`dotnet test -- --coverage`), uploading the `.coverage` files. Referencing a collector without invoking it is worse than none — it reads as coverage in the dependency list while producing nothing, which is exactly what `coverlet.collector` is doing in a sibling repo.

## Checklist

- [x] Build is clean — zero warnings
- [x] Tests pass on every shipped target framework — 290/290, plus a `.coverage` file per framework
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Dependency floors unchanged — **proven by byte-identical nuspec**

## Consumer impact

None, and this is the one change in the sequence where that claim needed proving rather than asserting. The nuspec diff is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)