### PR TITLE
docs: record the flaky Keychain delete test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,26 @@
 # TODO
 
+## Flaky test: KeychainCredentialManagerTests.DeleteCredentialAsync_RemovesCredential
+
+Observed 2026-08-20 on `macos-latest`, net10.0/arm64: `Assert.True(deleted)` failed
+(`DeleteCredentialAsync` returned false) at `KeychainCredentialManagerTests.cs:213`. The
+net8.0/arm64 leg of the same job passed, and a re-run of the identical commit passed
+cleanly — so it is a race, not a deterministic failure.
+
+Two things changed shortly before it appeared, both of which alter timing rather than
+behaviour: the test project began multi-targeting, so two test processes now run
+concurrently against the same login keychain, and coverage instrumentation was enabled.
+The app identifier is already a per-instance GUID, so this is not namespace collision
+between the two runs — more likely `SecItemDelete` racing `SecItemAdd` visibility under
+concurrent keychain access.
+
+Worth fixing rather than re-running: a flaky security-critical test trains people to ignore
+red. Candidate approaches — retry the delete assertion against a short deadline, or have
+the manager confirm deletion by re-querying rather than trusting the status code.
+
+The libsecret tests share the same shape (concurrent runs against one Secret Service) and
+have not failed yet, which is not the same as being correct.
+
 ## Credential store backends
 
 `LocalFileCredentialEncryption` protects credentials with AES-GCM but relies on


### PR DESCRIPTION
## What

Records a flaky test in `TODO.md` so the evidence survives the CI log ageing out.

`KeychainCredentialManagerTests.DeleteCredentialAsync_RemovesCredential` failed once on `macos-latest` net10.0/arm64 during #14 — `Assert.True(deleted)` at line 213, meaning `DeleteCredentialAsync` returned false. The net8.0/arm64 leg of the *same job* passed, and re-running the identical commit passed cleanly. That makes it a race, not a deterministic failure.

## Why it's worth writing down rather than shrugging at

A flaky test in the credential-**deletion** path is the kind that trains people to hit re-run instead of investigate.

Two things changed shortly before it appeared, both timing rather than behaviour: the test project started multi-targeting (so two processes now exercise the same login keychain concurrently), and coverage instrumentation was enabled. The app identifier is already a per-instance GUID, so this is **not** namespace collision between the two runs — more likely `SecItemDelete` racing `SecItemAdd` visibility.

The libsecret tests have the same shape — concurrent runs against one Secret Service — and have not failed yet, which is not the same as being correct.

## Checklist

- [x] Build is clean — docs only
- [x] Tests pass — unchanged
- [ ] `CHANGELOG.md` — not updated; `TODO.md` is the right home for outstanding hardening and this is not a consumer-visible change
- [x] Dependency floors unchanged

## Consumer impact

None. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)