### PR TITLE
ci: exclude obj/ and bin/ from CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,6 +46,13 @@ jobs:
           # security-and-quality is broader than the default security-extended;
           # these are small libraries, so the extra findings are affordable.
           queries: security-and-quality
+          # Analyse source only. obj/ and bin/ hold generated and compiled
+          # output — e.g. the xUnit auto-generated entry point — so findings
+          # there are noise against code no human maintains.
+          config: |
+            paths-ignore:
+              - "**/obj/**"
+              - "**/bin/**"
 
       # Explicit build rather than autobuild: these repos multi-target, and
       # autobuild has picked a single TFM in the past, silently analysing half

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CodeQL now excludes generated and build output.** A `paths-ignore` for `**/obj/**`
+  and `**/bin/**` was added to the analysis config so findings no longer surface against
+  code no human maintains (e.g. the xUnit auto-generated entry point). The
+  `cs/unmanaged-code` and `cs/call-to-unmanaged-code` notes on the native-backend P/Invoke
+  (Keychain, libsecret, DPAPI) are inherent to what this package does and have been
+  dismissed as *won't fix*; they are not defects.
+
 - **Central Package Management adopted.** Versions move from the two project files to a
   root `Directory.Packages.props`, with `CentralPackageVersionOverrideEnabled=false` so a
   stray inline `Version=` is a hard build error rather than being silently ignored. The


### PR DESCRIPTION
## What

Add a `paths-ignore` for `**/obj/**` and `**/bin/**` to the CodeQL analysis config.

## Why

After standards adoption, code scanning surfaced 154 open alerts — all `note` severity. A chunk of them point at generated/compiled output (e.g. `obj/Release/net{8,10}.0/XunitAutoGeneratedEntryPoint.cs`), which no human maintains. Excluding `obj/`/`bin/` removes that noise so real findings aren't buried.

Separately, the ~104 `cs/unmanaged-code` / `cs/call-to-unmanaged-code` notes are inherent to this package's native backends (Keychain, libsecret, DPAPI) and are being dismissed as *won't fix* via the API — they are not defects and there is no code change for them.

The same `paths-ignore` change lands in the `NextIteration.Standards` template and STANDARD.md §4.4, and in the sibling repos, as a coordinated rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)