### PR TITLE
feat: export/import the whole credential set (breaking ICredentialManager change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`accounts export` and `accounts import` — move your whole credential set between
+  machines.** On-disk credential ciphertext is machine-bound (each backend keys off
+  machine/user identity or an OS secret store), so the raw files can't be copied across
+  machines. Export instead reads every credential *decrypted* and re-encrypts the whole
+  set into a single portable archive under a **user-supplied passphrase** (AES-256-GCM
+  over PBKDF2-HMAC-SHA256, 600k iterations, random per-export salt); import decrypts it and
+  re-stores each credential through the normal backend path, re-protecting it under the
+  destination machine's key/store. The archive holds every secret protected only by the
+  passphrase, so the export command warns accordingly and writes the file `0600` on Unix.
+  - Export always requires a passphrase (prompted and confirmed, or read from an env var
+    via `--passphrase-env` for scripts); there is no plaintext export path.
+  - Import matches an incoming credential to an existing one on
+    *(provider, account name, environment)* and, on a collision, prompts per conflict for
+    skip/overwrite. `--on-conflict skip|overwrite` makes it non-interactive; a
+    non-interactive run with no flag defaults to `skip`.
+  - AccountId and selection state are preserved on all backends; `CreatedAt` is preserved
+    on the file and libsecret backends. On the macOS Keychain the creation timestamp is
+    assigned by the OS, so a restored item gets a fresh one (cosmetic only).
+
 ### Changed
+
+- **BREAKING: `ICredentialManager` gains two members** — `ExportCredentialsAsync()` and
+  `RestoreCredentialAsync(CredentialExport)`, plus the new public `CredentialExport` record
+  (a full-fidelity credential including its *decrypted* payload). These back the new
+  export/import commands and let each backend enumerate/restore natively rather than
+  composing it above the interface. Any external `ICredentialManager` implementation must
+  add both members; this warrants a **major version bump** and a matching update to the
+  downstream provider packages' capped dependency range.
 
 - **CodeQL now excludes generated and build output.** A `paths-ignore` for `**/obj/**`
   and `**/bin/**` was added to the analysis config so findings no longer surface against

--- a/README.md
+++ b/README.md
@@ -109,8 +109,29 @@ public sealed class SyncCommand(AdobeAuthenticationService auth) : AsyncCommand
 | `accounts list` | Table of stored credentials, grouped by provider, with provider-specific columns (masked tokens, URLs, etc.). |
 | `accounts select [id]` | Mark one credential as the active one for its provider. Subsequent `AuthenticateAsync()` calls use it. |
 | `accounts delete [id] [--force]` | Remove a credential. Clears the selection if it pointed at the deleted entry. |
+| `accounts export <file> [--force]` | Write every credential to a single passphrase-encrypted archive. |
+| `accounts import <file> [--on-conflict skip\|overwrite]` | Restore credentials from an archive into this machine's store. |
 
 Every command accepts `-v` / `--verbose` for full stack-trace output when something goes wrong.
+
+### Moving credentials between machines
+
+Stored credentials are encrypted with a **machine-bound** key (the local KEK is derived from machine/user identity; the Keychain/libsecret/DPAPI backends key off the OS secret store). That means the files on disk can't simply be copied to another machine — they won't decrypt there. `accounts export` / `accounts import` solve this by re-encrypting the whole set under a passphrase you carry:
+
+```console
+# On the old machine — you'll be prompted for a passphrase (and to confirm it):
+$ my-cli accounts export credentials.bundle
+Exported 4 credential(s) to credentials.bundle.
+
+# Copy credentials.bundle to the new machine, then:
+$ my-cli accounts import credentials.bundle
+```
+
+- **Passphrase-only.** The archive is AES-256-GCM encrypted with a PBKDF2-derived key (600,000 iterations, random per-export salt). There is no plaintext export. For scripting, read the passphrase from an environment variable with `--passphrase-env MY_VAR` instead of being prompted. On Unix the archive file is written `0600`.
+- **Conflicts.** An imported credential is matched to an existing one on *(provider, account name, environment)*. On a match you're prompted to skip or overwrite; pass `--on-conflict skip` or `--on-conflict overwrite` to decide up front (a non-interactive run with no flag skips).
+- **Fidelity.** Account IDs and which credential is selected are preserved. Original creation timestamps are preserved on the file and libsecret backends; the macOS Keychain assigns its own, so imported items show a fresh timestamp there.
+
+> The archive contains **every stored secret**, protected only by your passphrase. Choose a strong one and treat the file as sensitive.
 
 ---
 

--- a/src/NextIteration.SpectreConsole.Auth/CommandConfiguratorExtensions.cs
+++ b/src/NextIteration.SpectreConsole.Auth/CommandConfiguratorExtensions.cs
@@ -37,6 +37,15 @@ namespace NextIteration.SpectreConsole.Auth
                     .WithDescription("Select an active credential")
                     .WithExample("accounts", "select", "12345678-1234-1234-1234-123456789012")
                     .WithExample("accounts", "select");
+
+                accounts.AddCommand<ExportCredentialsCommand>("export")
+                    .WithDescription("Export all credentials to an encrypted archive")
+                    .WithExample("accounts", "export", "credentials.bundle");
+
+                accounts.AddCommand<ImportCredentialsCommand>("import")
+                    .WithDescription("Import credentials from an encrypted archive")
+                    .WithExample("accounts", "import", "credentials.bundle")
+                    .WithExample("accounts", "import", "credentials.bundle", "--on-conflict", "overwrite");
             });
 
             return configurator;

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ExportCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ExportCredentialsCommand.cs
@@ -1,0 +1,120 @@
+using Spectre.Console;
+using System.ComponentModel;
+
+using NextIteration.SpectreConsole.Auth.Persistence;
+using NextIteration.SpectreConsole.Auth.Portability;
+using Spectre.Console.Cli;
+
+namespace NextIteration.SpectreConsole.Auth.Commands
+{
+    /// <summary>
+    /// Spectre.Console command for the <c>accounts export</c> branch. Writes
+    /// every stored credential to a single passphrase-encrypted archive file so
+    /// the whole set can be moved to another machine and re-imported with
+    /// <see cref="ImportCredentialsCommand"/>.
+    /// </summary>
+    /// <remarks>DI constructor.</remarks>
+    public sealed class ExportCredentialsCommand(ICredentialManager credentialManager) : AsyncCommand<ExportCredentialsCommand.Settings>
+    {
+        private readonly ICredentialManager _credentialManager = credentialManager;
+
+        /// <inheritdoc />
+        protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (File.Exists(settings.File) && !settings.Force)
+                {
+                    AnsiConsole.MarkupLine($"[red]File already exists: {Markup.Escape(settings.File)}. Pass --force to overwrite.[/]");
+                    return 1;
+                }
+
+                var passphrase = await ResolveExportPassphraseAsync(settings, cancellationToken).ConfigureAwait(false);
+                if (passphrase is null)
+                {
+                    // ResolveExportPassphraseAsync has already reported why.
+                    return 1;
+                }
+
+                var service = new CredentialPortabilityService(_credentialManager);
+                var result = await service.ExportAsync(passphrase).ConfigureAwait(false);
+
+                if (result.Count == 0)
+                {
+                    AnsiConsole.MarkupLine("[yellow]No credentials to export.[/]");
+                    return 0;
+                }
+
+                // 0600 on Unix so the archive isn't world-readable while it sits
+                // on disk; on Windows it inherits the directory ACL.
+                await AtomicFile.WriteAllTextAsync(
+                    settings.File,
+                    result.Bundle,
+                    OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);
+
+                AnsiConsole.MarkupLine($"[green]Exported {result.Count} credential(s) to {Markup.Escape(settings.File)}.[/]");
+                AnsiConsole.MarkupLine("[grey]The archive holds every secret, protected only by the passphrase. Keep it and the passphrase safe.[/]");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                CommandErrorReporter.Report(ex, "Error exporting credentials", settings.Verbose);
+                return 1;
+            }
+        }
+
+        private static async Task<string?> ResolveExportPassphraseAsync(Settings settings, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(settings.PassphraseEnv))
+            {
+                var value = Environment.GetEnvironmentVariable(settings.PassphraseEnv);
+                if (string.IsNullOrEmpty(value))
+                {
+                    AnsiConsole.MarkupLine($"[red]Environment variable '{Markup.Escape(settings.PassphraseEnv)}' is not set or is empty.[/]");
+                    return null;
+                }
+
+                return value;
+            }
+
+            var passphrase = await AnsiConsole.PromptAsync(
+                new TextPrompt<string>("Enter a [green]passphrase[/] to protect the archive:")
+                    .Secret()
+                    .ValidationErrorMessage("[red]Passphrase cannot be empty[/]")
+                    .Validate(p => !string.IsNullOrEmpty(p)), cancellationToken).ConfigureAwait(false);
+
+            var confirm = await AnsiConsole.PromptAsync(
+                new TextPrompt<string>("[green]Confirm[/] passphrase:").Secret(), cancellationToken).ConfigureAwait(false);
+
+            if (!string.Equals(passphrase, confirm, StringComparison.Ordinal))
+            {
+                AnsiConsole.MarkupLine("[red]Passphrases did not match.[/]");
+                return null;
+            }
+
+            return passphrase;
+        }
+
+        /// <summary>CLI settings for <c>accounts export</c>.</summary>
+        public sealed class Settings : AccountsCommandSettings
+        {
+            /// <summary>Path the encrypted archive is written to.</summary>
+            [CommandArgument(0, "<FILE>")]
+            [Description("Path to write the encrypted archive to")]
+            public string File { get; set; } = string.Empty;
+
+            /// <summary>
+            /// Name of an environment variable to read the passphrase from
+            /// instead of prompting. Useful for scripts and CI.
+            /// </summary>
+            [CommandOption("--passphrase-env")]
+            [Description("Read the passphrase from this environment variable instead of prompting")]
+            public string? PassphraseEnv { get; set; }
+
+            /// <summary>Overwrite the target file if it already exists.</summary>
+            [CommandOption("-f|--force")]
+            [Description("Overwrite the target file if it exists")]
+            public bool Force { get; set; }
+        }
+    }
+}

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ImportCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ImportCredentialsCommand.cs
@@ -1,0 +1,163 @@
+using Spectre.Console;
+using System.ComponentModel;
+
+using NextIteration.SpectreConsole.Auth.Persistence;
+using NextIteration.SpectreConsole.Auth.Portability;
+using Spectre.Console.Cli;
+
+namespace NextIteration.SpectreConsole.Auth.Commands
+{
+    /// <summary>
+    /// Spectre.Console command for the <c>accounts import</c> branch. Reads a
+    /// passphrase-encrypted archive produced by
+    /// <see cref="ExportCredentialsCommand"/> and restores its credentials into
+    /// the local store, re-encrypting each under this machine's backend.
+    /// </summary>
+    /// <remarks>DI constructor.</remarks>
+    public sealed class ImportCredentialsCommand(ICredentialManager credentialManager) : AsyncCommand<ImportCredentialsCommand.Settings>
+    {
+        private readonly ICredentialManager _credentialManager = credentialManager;
+
+        /// <inheritdoc />
+        protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings, CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (!File.Exists(settings.File))
+                {
+                    AnsiConsole.MarkupLine($"[red]File not found: {Markup.Escape(settings.File)}[/]");
+                    return 1;
+                }
+
+                if (!TryResolveConflictMode(settings.OnConflict, out var forcedResolution))
+                {
+                    AnsiConsole.MarkupLine($"[red]Invalid --on-conflict value '{Markup.Escape(settings.OnConflict!)}'. Use 'skip' or 'overwrite'.[/]");
+                    return 1;
+                }
+
+                var passphrase = await ResolveImportPassphraseAsync(settings, cancellationToken).ConfigureAwait(false);
+                if (passphrase is null)
+                {
+                    return 1;
+                }
+
+                var bundle = await File.ReadAllTextAsync(settings.File, cancellationToken).ConfigureAwait(false);
+
+                var resolver = BuildConflictResolver(settings.OnConflict, forcedResolution);
+
+                var service = new CredentialPortabilityService(_credentialManager);
+                var result = await service.ImportAsync(bundle, passphrase, resolver).ConfigureAwait(false);
+
+                AnsiConsole.MarkupLine(
+                    $"[green]Import complete:[/] {result.Added} added, {result.Overwritten} overwritten, {result.Skipped} skipped.");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                CommandErrorReporter.Report(ex, "Error importing credentials", settings.Verbose);
+                return 1;
+            }
+        }
+
+        private static async Task<string?> ResolveImportPassphraseAsync(Settings settings, CancellationToken cancellationToken)
+        {
+            if (!string.IsNullOrEmpty(settings.PassphraseEnv))
+            {
+                var value = Environment.GetEnvironmentVariable(settings.PassphraseEnv);
+                if (string.IsNullOrEmpty(value))
+                {
+                    AnsiConsole.MarkupLine($"[red]Environment variable '{Markup.Escape(settings.PassphraseEnv)}' is not set or is empty.[/]");
+                    return null;
+                }
+
+                return value;
+            }
+
+            return await AnsiConsole.PromptAsync(
+                new TextPrompt<string>("Enter the archive [green]passphrase[/]:")
+                    .Secret()
+                    .ValidationErrorMessage("[red]Passphrase cannot be empty[/]")
+                    .Validate(p => !string.IsNullOrEmpty(p)), cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Maps the <c>--on-conflict</c> value to a fixed resolution.
+        /// Returns <see langword="false"/> only when the value is present but
+        /// unrecognised; a null/empty value is valid (interactive / default).
+        /// </summary>
+        private static bool TryResolveConflictMode(string? onConflict, out ConflictResolution resolution)
+        {
+            resolution = ConflictResolution.Skip;
+            if (string.IsNullOrEmpty(onConflict))
+            {
+                return true;
+            }
+
+            if (string.Equals(onConflict, "skip", StringComparison.OrdinalIgnoreCase))
+            {
+                resolution = ConflictResolution.Skip;
+                return true;
+            }
+
+            if (string.Equals(onConflict, "overwrite", StringComparison.OrdinalIgnoreCase))
+            {
+                resolution = ConflictResolution.Overwrite;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static Func<CredentialExport, CredentialExport, ConflictResolution> BuildConflictResolver(
+            string? onConflict, ConflictResolution forcedResolution)
+        {
+            // An explicit --on-conflict pins the decision for every collision.
+            if (!string.IsNullOrEmpty(onConflict))
+            {
+                return (_, _) => forcedResolution;
+            }
+
+            // No flag: prompt per conflict when we have an interactive terminal,
+            // otherwise fall back to the safe default (skip) so scripted runs
+            // don't hang on a prompt.
+            if (!AnsiConsole.Profile.Capabilities.Interactive)
+            {
+                return (_, _) => ConflictResolution.Skip;
+            }
+
+            return (incoming, _) => AnsiConsole.Confirm(
+                $"Credential '{Markup.Escape(incoming.AccountName)}' ({Markup.Escape(incoming.ProviderName)}/{Markup.Escape(incoming.Environment)}) already exists. Overwrite?",
+                defaultValue: false)
+                    ? ConflictResolution.Overwrite
+                    : ConflictResolution.Skip;
+        }
+
+        /// <summary>CLI settings for <c>accounts import</c>.</summary>
+        public sealed class Settings : AccountsCommandSettings
+        {
+            /// <summary>Path to the encrypted archive to import.</summary>
+            [CommandArgument(0, "<FILE>")]
+            [Description("Path to the encrypted archive to import")]
+            public string File { get; set; } = string.Empty;
+
+            /// <summary>
+            /// Name of an environment variable to read the passphrase from
+            /// instead of prompting. Useful for scripts and CI.
+            /// </summary>
+            [CommandOption("--passphrase-env")]
+            [Description("Read the passphrase from this environment variable instead of prompting")]
+            public string? PassphraseEnv { get; set; }
+
+            /// <summary>
+            /// How to resolve a credential that already exists (matched on
+            /// provider, account name, and environment): <c>skip</c> or
+            /// <c>overwrite</c>. When omitted, an interactive terminal is
+            /// prompted per conflict; a non-interactive run defaults to
+            /// <c>skip</c>.
+            /// </summary>
+            [CommandOption("--on-conflict")]
+            [Description("How to resolve existing credentials: skip or overwrite (default: prompt)")]
+            public string? OnConflict { get; set; }
+        }
+    }
+}

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
@@ -306,6 +306,100 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             return providers.OrderBy(p => p);
         }
 
+        /// <inheritdoc />
+        public async Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync()
+        {
+            // Every *.json in the directory except the selection record is a
+            // stored credential; mirrors the glob GetProviderNamesAsync uses.
+            var credentialFiles = Directory.GetFiles(_credentialsDirectory, "*.json")
+                .Where(f => !f.Equals(_selectionFile, StringComparison.OrdinalIgnoreCase));
+
+            var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+            var exports = new List<CredentialExport>();
+
+            foreach (var file in credentialFiles)
+            {
+                StoredCredential? credential;
+                try
+                {
+                    var content = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+                    credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
+                }
+                catch (JsonException)
+                {
+                    // Skip invalid JSON files (e.g. a stray .tmp that lost its race).
+                    continue;
+                }
+
+                if (credential is null)
+                {
+                    continue;
+                }
+
+                var isSelected = selections.TryGetValue(credential.ProviderName, out var selectedId) &&
+                    selectedId.Equals(credential.AccountId, StringComparison.OrdinalIgnoreCase);
+
+                var decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
+
+                exports.Add(new CredentialExport
+                {
+                    AccountId = credential.AccountId,
+                    AccountName = credential.AccountName,
+                    ProviderName = credential.ProviderName,
+                    Environment = credential.Environment,
+                    CredentialData = decrypted,
+                    CreatedAt = credential.CreatedAt,
+                    IsSelected = isSelected,
+                });
+            }
+
+            return exports;
+        }
+
+        /// <inheritdoc />
+        public async Task RestoreCredentialAsync(CredentialExport credential)
+        {
+            ArgumentNullException.ThrowIfNull(credential);
+
+            // credential comes from an imported archive — untrusted input, so
+            // both fields that flow into the file path are validated before use.
+            ValidateProviderName(credential.ProviderName);
+            ValidateAccountId(credential.AccountId);
+
+            var encryptedCredentialData = await _encryption.EncryptAsync(credential.CredentialData).ConfigureAwait(false);
+
+            var stored = new StoredCredential
+            {
+                AccountId = credential.AccountId,
+                AccountName = credential.AccountName,
+                ProviderName = credential.ProviderName,
+                Environment = credential.Environment,
+                CredentialData = encryptedCredentialData,
+                CreatedAt = credential.CreatedAt,
+            };
+
+            var fileName = $"{credential.ProviderName.ToLowerInvariant()}_{credential.AccountId}.json";
+            var filePath = Path.Combine(_credentialsDirectory, fileName);
+
+            var json = JsonSerializer.Serialize(stored, _jsonOptions);
+
+            // Atomic write to the deterministic path replaces any existing
+            // credential with the same provider + account id, so a re-import
+            // is idempotent rather than duplicating.
+            await AtomicFile.WriteAllTextAsync(
+                filePath,
+                json,
+                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);
+
+            if (credential.IsSelected)
+            {
+                using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile).ConfigureAwait(false);
+                var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+                selections[credential.ProviderName] = credential.AccountId;
+                await SaveSelectionsAsync(selections).ConfigureAwait(false);
+            }
+        }
+
         /// <summary>
         /// Restricts the set of characters allowed in a provider name so it is
         /// safe to use as a filename prefix. Prevents path-traversal attacks

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
@@ -67,6 +67,46 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// one stored credential.
         /// </summary>
         Task<IEnumerable<string>> GetProviderNamesAsync();
+
+        /// <summary>
+        /// Enumerates every stored credential across all providers, each with
+        /// its <b>decrypted</b> payload and current selection state. This is
+        /// the read half of the export/import feature and the counterpart to
+        /// <see cref="RestoreCredentialAsync"/>.
+        /// </summary>
+        /// <returns>
+        /// A snapshot of all stored credentials as <see cref="CredentialExport"/>
+        /// records. The list is empty when nothing is stored.
+        /// </returns>
+        /// <remarks>
+        /// Unlike <see cref="CredentialSummary"/>, the returned records carry
+        /// the plaintext <see cref="CredentialExport.CredentialData"/>. Handle
+        /// the result as secret material: never log it and don't persist it
+        /// unencrypted.
+        /// </remarks>
+        Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync();
+
+        /// <summary>
+        /// Recreates a credential from an export record, preserving its
+        /// <see cref="CredentialExport.AccountId"/>, its
+        /// <see cref="CredentialExport.CreatedAt"/> (where the backend allows
+        /// it), and its selection state. Any existing credential with the same
+        /// <see cref="CredentialExport.ProviderName"/> and
+        /// <see cref="CredentialExport.AccountId"/> is replaced.
+        /// </summary>
+        /// <param name="credential">
+        /// The record to restore. Its <see cref="CredentialExport.CredentialData"/>
+        /// is the plaintext payload and is re-protected by the backend on write.
+        /// </param>
+        /// <remarks>
+        /// The record's <see cref="CredentialExport.ProviderName"/> and
+        /// <see cref="CredentialExport.AccountId"/> are validated before use —
+        /// this method is fed from imported archives, which are untrusted input.
+        /// The macOS Keychain backend assigns its own creation timestamp, so a
+        /// restored item's <see cref="CredentialExport.CreatedAt"/> is not
+        /// preserved there.
+        /// </remarks>
+        Task RestoreCredentialAsync(CredentialExport credential);
     }
 
     /// <summary>
@@ -102,5 +142,48 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// Empty when no summary provider is registered for this provider.
         /// </summary>
         public IReadOnlyList<KeyValuePair<string, string>> DisplayFields { get; init; } = [];
+    }
+
+    /// <summary>
+    /// A full-fidelity, portable snapshot of a single stored credential,
+    /// including its <b>decrypted</b> payload. Produced by
+    /// <see cref="ICredentialManager.ExportCredentialsAsync"/> and consumed by
+    /// <see cref="ICredentialManager.RestoreCredentialAsync"/> to move
+    /// credentials between machines.
+    /// </summary>
+    /// <remarks>
+    /// This type carries secret material in <see cref="CredentialData"/>.
+    /// Callers that serialise it — for example the <c>accounts export</c>
+    /// command — must encrypt the result before it touches disk; the built-in
+    /// export path protects it with a user-supplied passphrase.
+    /// </remarks>
+    public sealed class CredentialExport
+    {
+        /// <summary>Unique GUID assigned at the credential's original creation time.</summary>
+        public required string AccountId { get; init; }
+
+        /// <summary>User-supplied display name.</summary>
+        public required string AccountName { get; init; }
+
+        /// <summary>Provider this credential belongs to.</summary>
+        public required string ProviderName { get; init; }
+
+        /// <summary>Environment the credential targets.</summary>
+        public required string Environment { get; init; }
+
+        /// <summary>
+        /// The decrypted, plaintext credential payload (the same JSON that was
+        /// passed to <see cref="ICredentialManager.AddCredentialAsync"/>).
+        /// </summary>
+        public required string CredentialData { get; init; }
+
+        /// <summary>Timestamp at which the credential was originally added.</summary>
+        public required DateTime CreatedAt { get; init; }
+
+        /// <summary>
+        /// True when this credential was the active one for its provider at
+        /// export time. A restored credential with this set is re-selected.
+        /// </summary>
+        public required bool IsSelected { get; init; }
     }
 }

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
@@ -203,6 +203,80 @@ public sealed class KeychainCredentialManager : ICredentialManager
         return Task.FromResult<IEnumerable<string>>(names);
     }
 
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync()
+    {
+        var items = QueryAllItemsForApp(includeData: true);
+        var selectionCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+        var exports = new List<CredentialExport>();
+        foreach (var item in items)
+        {
+            // Skip the selection records; only real credential items are exported.
+            if (item.Service.EndsWith(SelectionsServiceSuffix, StringComparison.Ordinal))
+                continue;
+
+            var providerName = ProviderNameFromService(item.Service);
+            if (providerName is null || item.Account is null)
+                continue;
+
+            if (!selectionCache.TryGetValue(providerName, out var selectedId))
+            {
+                selectedId = ReadSelection(providerName);
+                selectionCache[providerName] = selectedId;
+            }
+
+            exports.Add(new CredentialExport
+            {
+                AccountId = item.Account,
+                AccountName = item.Label ?? string.Empty,
+                ProviderName = providerName,
+                Environment = item.Description ?? string.Empty,
+                CredentialData = item.Data is not null ? Encoding.UTF8.GetString(item.Data) : string.Empty,
+                CreatedAt = item.CreatedAt ?? DateTime.MinValue,
+                IsSelected = selectedId is not null && string.Equals(selectedId, item.Account, StringComparison.OrdinalIgnoreCase),
+            });
+        }
+
+        return Task.FromResult<IReadOnlyList<CredentialExport>>(exports);
+    }
+
+    /// <inheritdoc />
+    public Task RestoreCredentialAsync(CredentialExport credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ValidateProviderName(credential.ProviderName);
+        ValidateAccountId(credential.AccountId);
+
+        var service = ServiceFor(credential.ProviderName);
+
+        // Replace any existing item with the same service + account id so a
+        // re-import is idempotent. Keychain has no atomic upsert, so delete
+        // then add — the creation date is reassigned by macOS regardless, so
+        // CreatedAt is intentionally not carried across.
+        var existing = QuerySingleItem(service, credential.AccountId, includeData: false);
+        if (existing is not null)
+        {
+            DeleteItem(service, credential.AccountId);
+        }
+
+        AddItem(new KeychainItem
+        {
+            Service = service,
+            Account = credential.AccountId,
+            Label = credential.AccountName,
+            Description = credential.Environment,
+            Data = Encoding.UTF8.GetBytes(credential.CredentialData),
+        });
+
+        if (credential.IsSelected)
+        {
+            WriteSelection(credential.ProviderName, credential.AccountId);
+        }
+
+        return Task.CompletedTask;
+    }
+
     // =========================
     // Internal helpers
     // =========================

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
@@ -247,6 +247,82 @@ public sealed class LibsecretCredentialManager : ICredentialManager
         return Task.FromResult<IEnumerable<string>>(names!);
     }
 
+    /// <inheritdoc />
+    public Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync()
+    {
+        var items = SearchItems(
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                [AttrApp] = _appIdentifier,
+                [AttrKind] = KindCredential,
+            },
+            loadSecrets: true);
+
+        var selectionCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+
+        var exports = new List<CredentialExport>();
+        foreach (var item in items)
+        {
+            var providerName = item.Attributes.GetValueOrDefault(AttrProvider);
+            if (string.IsNullOrEmpty(providerName))
+                continue;
+
+            if (!selectionCache.TryGetValue(providerName, out var selectedId))
+            {
+                selectedId = ReadSelection(providerName);
+                selectionCache[providerName] = selectedId;
+            }
+
+            var accountId = item.Attributes.GetValueOrDefault(AttrAccount, string.Empty);
+
+            exports.Add(new CredentialExport
+            {
+                AccountId = accountId,
+                AccountName = item.Attributes.GetValueOrDefault(AttrLabel, string.Empty),
+                ProviderName = providerName,
+                Environment = item.Attributes.GetValueOrDefault(AttrEnvironment, string.Empty),
+                CredentialData = item.Secret ?? string.Empty,
+                CreatedAt = ParseCreatedAt(item.Attributes.GetValueOrDefault(AttrCreatedAt)),
+                IsSelected = selectedId is not null && string.Equals(selectedId, accountId, StringComparison.OrdinalIgnoreCase),
+            });
+        }
+
+        return Task.FromResult<IReadOnlyList<CredentialExport>>(exports);
+    }
+
+    /// <inheritdoc />
+    public Task RestoreCredentialAsync(CredentialExport credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ValidateProviderName(credential.ProviderName);
+        ValidateAccountId(credential.AccountId);
+
+        // store overwrites an item whose attributes match exactly, so writing
+        // with the same (app, kind, provider, account) replaces any existing
+        // entry — a re-import is idempotent. CreatedAt is carried across
+        // faithfully via the attribute.
+        var attrs = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [AttrApp] = _appIdentifier,
+            [AttrKind] = KindCredential,
+            [AttrProvider] = credential.ProviderName,
+            [AttrAccount] = credential.AccountId,
+            [AttrLabel] = credential.AccountName,
+            [AttrEnvironment] = credential.Environment,
+            [AttrCreatedAt] = credential.CreatedAt.ToString("O"),
+        };
+        var label = $"{_appIdentifier}: {credential.ProviderName}/{credential.AccountName}";
+
+        StoreItem(attrs, label, credential.CredentialData);
+
+        if (credential.IsSelected)
+        {
+            WriteSelection(credential.ProviderName, credential.AccountId);
+        }
+
+        return Task.CompletedTask;
+    }
+
     // =========================
     // Internal helpers
     // =========================

--- a/src/NextIteration.SpectreConsole.Auth/Portability/CredentialArchive.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Portability/CredentialArchive.cs
@@ -1,0 +1,266 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+
+using NextIteration.SpectreConsole.Auth.Persistence;
+
+namespace NextIteration.SpectreConsole.Auth.Portability
+{
+    /// <summary>
+    /// Serialises a set of <see cref="CredentialExport"/> records into a
+    /// portable, passphrase-encrypted archive and back. The archive is
+    /// backend-independent: the on-disk credential ciphertext is machine-bound,
+    /// so an archive holds the <em>decrypted</em> payloads re-encrypted under a
+    /// passphrase the user carries between machines.
+    /// </summary>
+    /// <remarks>
+    /// The envelope is JSON with a random per-export salt; the payload is
+    /// AES-256-GCM over PBKDF2-HMAC-SHA256(passphrase, salt). Layout of the
+    /// encrypted payload is <c>[nonce(12)][tag(16)][ciphertext]</c> — the same
+    /// convention as <see cref="Encryption.LocalFileCredentialEncryption"/>.
+    /// </remarks>
+    internal static class CredentialArchive
+    {
+        private const string FormatMarker = "nextiteration-credential-archive";
+        private const string KdfMarker = "PBKDF2-HMAC-SHA256";
+        private const int CurrentVersion = 1;
+
+        private const int SaltSize = 16;
+        private const int NonceSize = 12;
+        private const int TagSize = 16;
+        private const int KeySize = 32; // AES-256
+        private const int Pbkdf2Iterations = 600_000; // matches LocalFileCredentialEncryption / OWASP 2023
+
+        private static readonly JsonSerializerOptions _jsonOptions = new()
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+
+        /// <summary>
+        /// Encrypts <paramref name="credentials"/> under <paramref name="passphrase"/>
+        /// and returns the archive as a JSON string ready to write to disk.
+        /// </summary>
+        internal static string Serialize(IReadOnlyList<CredentialExport> credentials, string passphrase)
+        {
+            ArgumentNullException.ThrowIfNull(credentials);
+            ArgumentException.ThrowIfNullOrEmpty(passphrase);
+
+            var payload = new ArchivePayload
+            {
+                ExportedAtUtc = DateTime.UtcNow,
+                Credentials = credentials.Select(ArchiveCredential.From).ToList(),
+            };
+
+            var plaintext = JsonSerializer.SerializeToUtf8Bytes(payload, _jsonOptions);
+            var salt = RandomNumberGenerator.GetBytes(SaltSize);
+            var key = Rfc2898DeriveBytes.Pbkdf2(passphrase, salt, Pbkdf2Iterations, HashAlgorithmName.SHA256, KeySize);
+
+            try
+            {
+                var encrypted = EncryptWithGcm(key, plaintext);
+
+                var envelope = new ArchiveEnvelope
+                {
+                    Format = FormatMarker,
+                    Version = CurrentVersion,
+                    Kdf = KdfMarker,
+                    Iterations = Pbkdf2Iterations,
+                    Salt = Convert.ToBase64String(salt),
+                    Payload = Convert.ToBase64String(encrypted),
+                };
+
+                return JsonSerializer.Serialize(envelope, _jsonOptions);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(key);
+                CryptographicOperations.ZeroMemory(plaintext);
+            }
+        }
+
+        /// <summary>
+        /// Reverses <see cref="Serialize"/>. Throws
+        /// <see cref="InvalidOperationException"/> when the input is not an
+        /// archive, is an unsupported version, is corrupt, or the passphrase is
+        /// wrong (integrity-check failure).
+        /// </summary>
+        internal static IReadOnlyList<CredentialExport> Deserialize(string bundle, string passphrase)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(bundle);
+            ArgumentException.ThrowIfNullOrEmpty(passphrase);
+
+            ArchiveEnvelope? envelope;
+            try
+            {
+                envelope = JsonSerializer.Deserialize<ArchiveEnvelope>(bundle, _jsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException("The file is not a valid credential archive.", ex);
+            }
+
+            if (envelope is null || !string.Equals(envelope.Format, FormatMarker, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("The file is not a credential archive.");
+            }
+
+            if (envelope.Version != CurrentVersion)
+            {
+                throw new InvalidOperationException(
+                    $"Unsupported credential archive version {envelope.Version}; this build understands version {CurrentVersion}.");
+            }
+
+            if (string.IsNullOrEmpty(envelope.Salt) || string.IsNullOrEmpty(envelope.Payload))
+            {
+                throw new InvalidOperationException("The credential archive is missing its salt or payload.");
+            }
+
+            byte[] salt;
+            byte[] encrypted;
+            try
+            {
+                salt = Convert.FromBase64String(envelope.Salt);
+                encrypted = Convert.FromBase64String(envelope.Payload);
+            }
+            catch (FormatException ex)
+            {
+                throw new InvalidOperationException("The credential archive is corrupt (invalid base64).", ex);
+            }
+
+            // Honour the archive's stated iteration count so archives written by
+            // a future build with a different cost still open; fall back to the
+            // current default if the field is absent or nonsensical.
+            var iterations = envelope.Iterations > 0 ? envelope.Iterations : Pbkdf2Iterations;
+            var key = Rfc2898DeriveBytes.Pbkdf2(passphrase, salt, iterations, HashAlgorithmName.SHA256, KeySize);
+
+            byte[] plaintext;
+            try
+            {
+                plaintext = DecryptWithGcm(key, encrypted);
+            }
+            catch (AuthenticationTagMismatchException ex)
+            {
+                throw new InvalidOperationException(
+                    "Could not decrypt the credential archive. The passphrase is wrong, or the file has been modified.", ex);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(key);
+            }
+
+            try
+            {
+                var payload = JsonSerializer.Deserialize<ArchivePayload>(plaintext, _jsonOptions);
+                var credentials = payload?.Credentials ?? [];
+                return credentials.Select(c => c.ToExport()).ToList();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException("The credential archive decrypted but its contents are malformed.", ex);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(plaintext);
+            }
+        }
+
+        /// <summary>
+        /// AES-GCM encrypt with output layout <c>[nonce(12)][tag(16)][ciphertext]</c>.
+        /// </summary>
+        private static byte[] EncryptWithGcm(byte[] key, byte[] plaintext)
+        {
+            var nonce = RandomNumberGenerator.GetBytes(NonceSize);
+            var ciphertext = new byte[plaintext.Length];
+            var tag = new byte[TagSize];
+
+            using var aes = new AesGcm(key, TagSize);
+            aes.Encrypt(nonce, plaintext, ciphertext, tag);
+
+            var output = new byte[NonceSize + TagSize + ciphertext.Length];
+            Buffer.BlockCopy(nonce, 0, output, 0, NonceSize);
+            Buffer.BlockCopy(tag, 0, output, NonceSize, TagSize);
+            Buffer.BlockCopy(ciphertext, 0, output, NonceSize + TagSize, ciphertext.Length);
+            return output;
+        }
+
+        /// <summary>
+        /// Reverses <see cref="EncryptWithGcm"/>; throws
+        /// <see cref="AuthenticationTagMismatchException"/> on a wrong key or
+        /// tampered payload.
+        /// </summary>
+        private static byte[] DecryptWithGcm(byte[] key, byte[] input)
+        {
+            if (input.Length < NonceSize + TagSize)
+            {
+                throw new InvalidOperationException("The credential archive payload is shorter than the AES-GCM header.");
+            }
+
+            var nonce = new byte[NonceSize];
+            var tag = new byte[TagSize];
+            var ciphertextLength = input.Length - NonceSize - TagSize;
+            var ciphertext = new byte[ciphertextLength];
+
+            Buffer.BlockCopy(input, 0, nonce, 0, NonceSize);
+            Buffer.BlockCopy(input, NonceSize, tag, 0, TagSize);
+            Buffer.BlockCopy(input, NonceSize + TagSize, ciphertext, 0, ciphertextLength);
+
+            var plaintext = new byte[ciphertextLength];
+            using var aes = new AesGcm(key, TagSize);
+            aes.Decrypt(nonce, ciphertext, tag, plaintext);
+            return plaintext;
+        }
+
+        // Non-secret envelope written in clear so the archive is self-describing.
+        private sealed class ArchiveEnvelope
+        {
+            public string Format { get; set; } = string.Empty;
+            public int Version { get; set; }
+            public string Kdf { get; set; } = string.Empty;
+            public int Iterations { get; set; }
+            public string Salt { get; set; } = string.Empty;
+            public string Payload { get; set; } = string.Empty;
+        }
+
+        // The encrypted payload — never written to disk in the clear.
+        private sealed class ArchivePayload
+        {
+            public DateTime ExportedAtUtc { get; set; }
+            public List<ArchiveCredential> Credentials { get; set; } = [];
+        }
+
+        // Lenient DTO (settable, defaulted) so a slightly-off archive fails with
+        // a clear message during mapping rather than a required-member throw.
+        private sealed class ArchiveCredential
+        {
+            public string AccountId { get; set; } = string.Empty;
+            public string AccountName { get; set; } = string.Empty;
+            public string ProviderName { get; set; } = string.Empty;
+            public string Environment { get; set; } = string.Empty;
+            public string CredentialData { get; set; } = string.Empty;
+            public DateTime CreatedAt { get; set; }
+            public bool IsSelected { get; set; }
+
+            public static ArchiveCredential From(CredentialExport c) => new()
+            {
+                AccountId = c.AccountId,
+                AccountName = c.AccountName,
+                ProviderName = c.ProviderName,
+                Environment = c.Environment,
+                CredentialData = c.CredentialData,
+                CreatedAt = c.CreatedAt,
+                IsSelected = c.IsSelected,
+            };
+
+            public CredentialExport ToExport() => new()
+            {
+                AccountId = AccountId,
+                AccountName = AccountName,
+                ProviderName = ProviderName,
+                Environment = Environment,
+                CredentialData = CredentialData,
+                CreatedAt = CreatedAt,
+                IsSelected = IsSelected,
+            };
+        }
+    }
+}

--- a/src/NextIteration.SpectreConsole.Auth/Portability/CredentialPortabilityService.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Portability/CredentialPortabilityService.cs
@@ -1,0 +1,131 @@
+using NextIteration.SpectreConsole.Auth.Persistence;
+
+namespace NextIteration.SpectreConsole.Auth.Portability
+{
+    /// <summary>
+    /// How an import should treat an incoming credential that collides with an
+    /// existing one (same provider, account name, and environment).
+    /// </summary>
+    internal enum ConflictResolution
+    {
+        /// <summary>Leave the existing credential untouched; drop the incoming one.</summary>
+        Skip,
+
+        /// <summary>Replace the existing credential with the incoming one.</summary>
+        Overwrite,
+    }
+
+    /// <summary>Outcome of an <see cref="CredentialPortabilityService.ExportAsync"/> call.</summary>
+    /// <param name="Bundle">The passphrase-encrypted archive text.</param>
+    /// <param name="Count">Number of credentials written into the archive.</param>
+    internal sealed record ExportResult(string Bundle, int Count);
+
+    /// <summary>Outcome of an <see cref="CredentialPortabilityService.ImportAsync"/> call.</summary>
+    /// <param name="Added">Credentials that did not exist and were created.</param>
+    /// <param name="Overwritten">Existing credentials that were replaced.</param>
+    /// <param name="Skipped">Colliding credentials left untouched.</param>
+    internal sealed record ImportResult(int Added, int Overwritten, int Skipped);
+
+    /// <summary>
+    /// Backend-agnostic orchestration for whole-store export and import. Sits
+    /// entirely above <see cref="ICredentialManager"/> so it works uniformly
+    /// across the file, Keychain, and libsecret backends, and is unit-testable
+    /// without the interactive command layer (the conflict decision is injected
+    /// as a delegate).
+    /// </summary>
+    internal sealed class CredentialPortabilityService
+    {
+        private readonly ICredentialManager _manager;
+
+        internal CredentialPortabilityService(ICredentialManager manager)
+        {
+            ArgumentNullException.ThrowIfNull(manager);
+            _manager = manager;
+        }
+
+        /// <summary>
+        /// Reads every stored credential and returns it as a passphrase-encrypted
+        /// archive.
+        /// </summary>
+        internal async Task<ExportResult> ExportAsync(string passphrase)
+        {
+            var credentials = await _manager.ExportCredentialsAsync().ConfigureAwait(false);
+            var bundle = CredentialArchive.Serialize(credentials, passphrase);
+            return new ExportResult(bundle, credentials.Count);
+        }
+
+        /// <summary>
+        /// Decrypts an archive and restores its credentials into the store.
+        /// A credential that matches an existing one on (provider, account name,
+        /// environment) is routed to <paramref name="resolveConflict"/> to decide
+        /// skip vs. overwrite; a credential with no match is added.
+        /// </summary>
+        /// <param name="bundle">The archive text produced by <see cref="ExportAsync"/>.</param>
+        /// <param name="passphrase">The passphrase the archive was written with.</param>
+        /// <param name="resolveConflict">
+        /// Called once per collision with (incoming, existing) and returns how to
+        /// resolve it. Invoked only when there is an actual conflict.
+        /// </param>
+        internal async Task<ImportResult> ImportAsync(
+            string bundle,
+            string passphrase,
+            Func<CredentialExport, CredentialExport, ConflictResolution> resolveConflict)
+        {
+            ArgumentNullException.ThrowIfNull(resolveConflict);
+
+            var incoming = CredentialArchive.Deserialize(bundle, passphrase);
+            var existing = await _manager.ExportCredentialsAsync().ConfigureAwait(false);
+
+            // Index existing credentials by their semantic identity. Duplicates
+            // on the same key are unusual but possible; keep the first as the
+            // conflict target.
+            var existingByKey = new Dictionary<string, CredentialExport>(StringComparer.Ordinal);
+            foreach (var e in existing)
+            {
+                _ = existingByKey.TryAdd(ConflictKey(e), e);
+            }
+
+            var added = 0;
+            var overwritten = 0;
+            var skipped = 0;
+
+            foreach (var entry in incoming)
+            {
+                if (existingByKey.TryGetValue(ConflictKey(entry), out var match))
+                {
+                    var resolution = resolveConflict(entry, match);
+                    if (resolution == ConflictResolution.Skip)
+                    {
+                        skipped++;
+                        continue;
+                    }
+
+                    // Overwrite: drop the existing credential (which may carry a
+                    // different account id) before restoring the incoming one.
+                    _ = await _manager.DeleteCredentialAsync(match.AccountId).ConfigureAwait(false);
+                    await _manager.RestoreCredentialAsync(entry).ConfigureAwait(false);
+                    overwritten++;
+                }
+                else
+                {
+                    await _manager.RestoreCredentialAsync(entry).ConfigureAwait(false);
+                    added++;
+                }
+            }
+
+            return new ImportResult(added, overwritten, skipped);
+        }
+
+        // Semantic identity used to detect "the same" credential across machines,
+        // where account ids differ. Case-insensitive on all three parts, and
+        // length-prefixed so no combination of separators inside a value can make
+        // two different triples collide onto one key.
+        private static string ConflictKey(CredentialExport c)
+        {
+            var provider = c.ProviderName.ToLowerInvariant();
+            var name = c.AccountName.ToLowerInvariant();
+            var environment = c.Environment.ToLowerInvariant();
+            return $"{provider.Length}:{provider}|{name.Length}:{name}|{environment.Length}:{environment}";
+        }
+    }
+}

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -499,6 +499,97 @@ public sealed class FileCredentialManagerTests
         Assert.True(airtable.IsSelected);
     }
 
+    [Fact]
+    public async Task ExportCredentialsAsync_ReturnsDecryptedPayloadAndSelection()
+    {
+        using var temp = new TempDir();
+        var manager = CreateManager(temp.Path);
+        var adobeId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
+        _ = await manager.AddCredentialAsync("Airtable", "main", "Production", "{\"apiKey\":\"other\"}");
+        Assert.True(await manager.SelectCredentialAsync(adobeId));
+
+        var exports = await manager.ExportCredentialsAsync();
+
+        Assert.Equal(2, exports.Count);
+        var adobe = exports.Single(c => c.ProviderName == "Adobe");
+        Assert.Equal("prod", adobe.AccountName);
+        Assert.Equal("Production", adobe.Environment);
+        Assert.Equal("{\"apiKey\":\"secret\"}", adobe.CredentialData); // decrypted
+        Assert.True(adobe.IsSelected);
+        Assert.False(exports.Single(c => c.ProviderName == "Airtable").IsSelected);
+    }
+
+    [Fact]
+    public async Task RestoreCredentialAsync_PreservesAccountIdCreatedAtAndSelection()
+    {
+        using var temp = new TempDir();
+        var manager = CreateManager(temp.Path);
+
+        var record = new CredentialExport
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            AccountName = "prod",
+            ProviderName = "Adobe",
+            Environment = "Production",
+            CredentialData = "{\"apiKey\":\"restored\"}",
+            CreatedAt = new DateTime(2018, 5, 6, 7, 8, 9, DateTimeKind.Utc),
+            IsSelected = true,
+        };
+
+        await manager.RestoreCredentialAsync(record);
+
+        var stored = Assert.Single(await manager.ExportCredentialsAsync());
+        Assert.Equal(record.AccountId, stored.AccountId);
+        Assert.Equal(record.CreatedAt, stored.CreatedAt);
+        Assert.True(stored.IsSelected);
+        Assert.Equal("{\"apiKey\":\"restored\"}", await manager.GetCredentialByIdAsync("Adobe", record.AccountId));
+    }
+
+    [Fact]
+    public async Task RestoreCredentialAsync_SameProviderAndId_ReplacesRatherThanDuplicates()
+    {
+        using var temp = new TempDir();
+        var manager = CreateManager(temp.Path);
+        var id = Guid.NewGuid().ToString();
+
+        CredentialExport Record(string payload) => new()
+        {
+            AccountId = id,
+            AccountName = "prod",
+            ProviderName = "Adobe",
+            Environment = "Production",
+            CredentialData = payload,
+            CreatedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            IsSelected = false,
+        };
+
+        await manager.RestoreCredentialAsync(Record("{\"v\":1}"));
+        await manager.RestoreCredentialAsync(Record("{\"v\":2}"));
+
+        var stored = Assert.Single(await manager.ExportCredentialsAsync());
+        Assert.Equal("{\"v\":2}", stored.CredentialData);
+    }
+
+    [Fact]
+    public async Task RestoreCredentialAsync_InvalidAccountId_Throws()
+    {
+        using var temp = new TempDir();
+        var manager = CreateManager(temp.Path);
+
+        var bad = new CredentialExport
+        {
+            AccountId = "../not-a-guid",
+            AccountName = "prod",
+            ProviderName = "Adobe",
+            Environment = "Production",
+            CredentialData = "{}",
+            CreatedAt = DateTime.UtcNow,
+            IsSelected = false,
+        };
+
+        _ = await Assert.ThrowsAsync<ArgumentException>(() => manager.RestoreCredentialAsync(bad));
+    }
+
     /// <summary>
     /// Minimal summary provider used only to verify that
     /// <see cref="FileCredentialManager.ListCredentialsAsync"/> routes

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -68,6 +68,44 @@ public sealed class KeychainCredentialManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task ExportCredentialsAsync_ReturnsDecryptedPayloadAndSelection()
+    {
+        if (_skip) return;
+        var manager = NewManager();
+        var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
+        Assert.True(await manager.SelectCredentialAsync(id));
+
+        var adobe = Assert.Single(await manager.ExportCredentialsAsync());
+        Assert.Equal(id, adobe.AccountId);
+        Assert.Equal("prod", adobe.AccountName);
+        Assert.Equal("Adobe", adobe.ProviderName);
+        Assert.Equal("Production", adobe.Environment);
+        Assert.Equal("{\"apiKey\":\"secret\"}", adobe.CredentialData);
+        Assert.True(adobe.IsSelected);
+    }
+
+    [Fact]
+    public async Task RestoreCredentialAsync_PreservesAccountIdAndSelection()
+    {
+        // The macOS Keychain assigns its own creation date, so CreatedAt is
+        // intentionally not asserted here (see RestoreCredentialAsync remarks).
+        if (_skip) return;
+        var manager = NewManager();
+        var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
+        _ = await manager.SelectCredentialAsync(id);
+        var exported = Assert.Single(await manager.ExportCredentialsAsync());
+
+        // Simulate an import: drop it, then restore from the export record.
+        Assert.True(await manager.DeleteCredentialAsync(id));
+        await manager.RestoreCredentialAsync(exported);
+
+        var restored = Assert.Single(await manager.ExportCredentialsAsync());
+        Assert.Equal(id, restored.AccountId);
+        Assert.True(restored.IsSelected);
+        Assert.Equal("{\"apiKey\":\"secret\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+    }
+
+    [Fact]
     public async Task AddCredentialAsync_ReturnsGuidAccountId()
     {
         if (_skip) return;

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -105,6 +105,43 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
     }
 
     [Fact]
+    public async Task ExportCredentialsAsync_ReturnsDecryptedPayloadAndSelection()
+    {
+        if (_skip) return;
+        var manager = NewManager();
+        var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
+        Assert.True(await manager.SelectCredentialAsync(id));
+
+        var adobe = Assert.Single(await manager.ExportCredentialsAsync());
+        Assert.Equal(id, adobe.AccountId);
+        Assert.Equal("prod", adobe.AccountName);
+        Assert.Equal("Adobe", adobe.ProviderName);
+        Assert.Equal("Production", adobe.Environment);
+        Assert.Equal("{\"apiKey\":\"secret\"}", adobe.CredentialData);
+        Assert.True(adobe.IsSelected);
+    }
+
+    [Fact]
+    public async Task RestoreCredentialAsync_PreservesAccountIdCreatedAtAndSelection()
+    {
+        if (_skip) return;
+        var manager = NewManager();
+        var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
+        _ = await manager.SelectCredentialAsync(id);
+        var exported = Assert.Single(await manager.ExportCredentialsAsync());
+
+        // Simulate an import: drop it, then restore from the export record.
+        Assert.True(await manager.DeleteCredentialAsync(id));
+        await manager.RestoreCredentialAsync(exported);
+
+        var restored = Assert.Single(await manager.ExportCredentialsAsync());
+        Assert.Equal(id, restored.AccountId);
+        Assert.Equal(exported.CreatedAt, restored.CreatedAt); // libsecret preserves it via attribute
+        Assert.True(restored.IsSelected);
+        Assert.Equal("{\"apiKey\":\"secret\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+    }
+
+    [Fact]
     public async Task AddCredentialAsync_ReturnsGuidAccountId()
     {
         if (_skip) return;

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Portability/CredentialArchiveTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Portability/CredentialArchiveTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json.Nodes;
+
+using NextIteration.SpectreConsole.Auth.Persistence;
+using NextIteration.SpectreConsole.Auth.Portability;
+
+using Xunit;
+
+namespace NextIteration.SpectreConsole.Auth.Tests.Portability;
+
+public sealed class CredentialArchiveTests
+{
+    private const string Passphrase = "correct horse battery staple";
+
+    private static CredentialExport Sample(string accountName, string payload, bool selected = false) => new()
+    {
+        AccountId = Guid.NewGuid().ToString(),
+        AccountName = accountName,
+        ProviderName = "Adobe",
+        Environment = "Production",
+        CredentialData = payload,
+        CreatedAt = new DateTime(2021, 6, 7, 8, 9, 10, DateTimeKind.Utc),
+        IsSelected = selected,
+    };
+
+    [Fact]
+    public void Serialize_Deserialize_RoundTripsAllFields()
+    {
+        var input = new List<CredentialExport>
+        {
+            Sample("prod", "{\"apiKey\":\"one\"}", selected: true),
+            Sample("sandbox", "{\"apiKey\":\"two\"}"),
+        };
+
+        var bundle = CredentialArchive.Serialize(input, Passphrase);
+        var output = CredentialArchive.Deserialize(bundle, Passphrase);
+
+        Assert.Equal(input.Count, output.Count);
+        for (var i = 0; i < input.Count; i++)
+        {
+            Assert.Equal(input[i].AccountId, output[i].AccountId);
+            Assert.Equal(input[i].AccountName, output[i].AccountName);
+            Assert.Equal(input[i].ProviderName, output[i].ProviderName);
+            Assert.Equal(input[i].Environment, output[i].Environment);
+            Assert.Equal(input[i].CredentialData, output[i].CredentialData);
+            Assert.Equal(input[i].CreatedAt, output[i].CreatedAt);
+            Assert.Equal(input[i].IsSelected, output[i].IsSelected);
+        }
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_EmptySet_RoundTrips()
+    {
+        var bundle = CredentialArchive.Serialize([], Passphrase);
+        var output = CredentialArchive.Deserialize(bundle, Passphrase);
+        Assert.Empty(output);
+    }
+
+    [Fact]
+    public void Deserialize_WrongPassphrase_Throws()
+    {
+        var bundle = CredentialArchive.Serialize([Sample("prod", "{}")], Passphrase);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => CredentialArchive.Deserialize(bundle, "not the passphrase"));
+        Assert.Contains("passphrase", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Deserialize_TamperedPayload_Throws()
+    {
+        var bundle = CredentialArchive.Serialize([Sample("prod", "{\"apiKey\":\"secret\"}")], Passphrase);
+
+        // Flip a byte inside the encrypted payload; AES-GCM's tag check must
+        // reject it rather than returning garbage plaintext.
+        var node = JsonNode.Parse(bundle)!;
+        var payload = Convert.FromBase64String(node["payload"]!.GetValue<string>());
+        payload[^1] ^= 0xFF;
+        node["payload"] = Convert.ToBase64String(payload);
+        var tampered = node.ToJsonString();
+
+        _ = Assert.Throws<InvalidOperationException>(
+            () => CredentialArchive.Deserialize(tampered, Passphrase));
+    }
+
+    [Fact]
+    public void Deserialize_NotAnArchive_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => CredentialArchive.Deserialize("this is not json", Passphrase));
+        Assert.Contains("archive", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Deserialize_UnsupportedVersion_Throws()
+    {
+        var bundle = CredentialArchive.Serialize([Sample("prod", "{}")], Passphrase);
+        var node = JsonNode.Parse(bundle)!;
+        node["version"] = 999;
+        var future = node.ToJsonString();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => CredentialArchive.Deserialize(future, Passphrase));
+        Assert.Contains("version", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Portability/CredentialPortabilityServiceTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Portability/CredentialPortabilityServiceTests.cs
@@ -1,0 +1,157 @@
+using NextIteration.SpectreConsole.Auth.Encryption;
+using NextIteration.SpectreConsole.Auth.Persistence;
+using NextIteration.SpectreConsole.Auth.Portability;
+using NextIteration.SpectreConsole.Auth.Tests.Infrastructure;
+
+using Xunit;
+
+namespace NextIteration.SpectreConsole.Auth.Tests.Portability;
+
+public sealed class CredentialPortabilityServiceTests
+{
+    private const string Passphrase = "move-me-between-machines";
+
+    private static FileCredentialManager NewManager(string directory) =>
+        new(new LocalFileCredentialEncryption(directory), directory);
+
+    private static async Task<CredentialExport> SingleExportAsync(FileCredentialManager manager) =>
+        (await manager.ExportCredentialsAsync()).Single();
+
+    [Fact]
+    public async Task ExportThenImport_RoundTripsAllFields_IntoFreshStore()
+    {
+        using var source = new TempDir();
+        using var target = new TempDir();
+
+        var sourceManager = NewManager(source.Path);
+        var adobeId = await sourceManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"a\"}");
+        _ = await sourceManager.AddCredentialAsync("Adobe", "sandbox", "Sandbox", "{\"k\":\"b\"}");
+        _ = await sourceManager.AddCredentialAsync("Airtable", "main", "Production", "{\"k\":\"c\"}");
+        Assert.True(await sourceManager.SelectCredentialAsync(adobeId));
+
+        var exportService = new CredentialPortabilityService(sourceManager);
+        var export = await exportService.ExportAsync(Passphrase);
+        Assert.Equal(3, export.Count);
+
+        var targetManager = NewManager(target.Path);
+        var importService = new CredentialPortabilityService(targetManager);
+        var result = await importService.ImportAsync(export.Bundle, Passphrase, (_, _) => ConflictResolution.Skip);
+
+        Assert.Equal(3, result.Added);
+        Assert.Equal(0, result.Overwritten);
+        Assert.Equal(0, result.Skipped);
+
+        var expected = (await sourceManager.ExportCredentialsAsync()).OrderBy(c => c.AccountId).ToList();
+        var actual = (await targetManager.ExportCredentialsAsync()).OrderBy(c => c.AccountId).ToList();
+
+        Assert.Equal(expected.Count, actual.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].AccountId, actual[i].AccountId);
+            Assert.Equal(expected[i].AccountName, actual[i].AccountName);
+            Assert.Equal(expected[i].ProviderName, actual[i].ProviderName);
+            Assert.Equal(expected[i].Environment, actual[i].Environment);
+            Assert.Equal(expected[i].CredentialData, actual[i].CredentialData);
+            Assert.Equal(expected[i].CreatedAt, actual[i].CreatedAt);
+            Assert.Equal(expected[i].IsSelected, actual[i].IsSelected);
+        }
+
+        // The selection followed the credential across the import.
+        var selected = actual.Single(c => c.IsSelected);
+        Assert.Equal("prod", selected.AccountName);
+        Assert.Equal("{\"k\":\"a\"}", await targetManager.GetSelectedCredentialAsync("Adobe"));
+    }
+
+    [Fact]
+    public async Task Import_Skip_IsIdempotent()
+    {
+        using var source = new TempDir();
+        using var target = new TempDir();
+
+        var sourceManager = NewManager(source.Path);
+        _ = await sourceManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"a\"}");
+        var bundle = (await new CredentialPortabilityService(sourceManager).ExportAsync(Passphrase)).Bundle;
+
+        var targetManager = NewManager(target.Path);
+        var importService = new CredentialPortabilityService(targetManager);
+
+        var first = await importService.ImportAsync(bundle, Passphrase, (_, _) => ConflictResolution.Skip);
+        Assert.Equal(1, first.Added);
+
+        var second = await importService.ImportAsync(bundle, Passphrase, (_, _) => ConflictResolution.Skip);
+        Assert.Equal(0, second.Added);
+        Assert.Equal(1, second.Skipped);
+
+        Assert.Single(await targetManager.ExportCredentialsAsync());
+    }
+
+    [Fact]
+    public async Task Import_Overwrite_ReplacesMatchingCredential()
+    {
+        using var target = new TempDir();
+        var targetManager = NewManager(target.Path);
+
+        // Pre-existing credential the incoming one will collide with.
+        _ = await targetManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"OLD\"}");
+
+        // Craft an incoming archive with the same identity (provider/name/env)
+        // but a different account id and payload.
+        var incoming = new CredentialExport
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            AccountName = "prod",
+            ProviderName = "Adobe",
+            Environment = "Production",
+            CredentialData = "{\"k\":\"NEW\"}",
+            CreatedAt = new DateTime(2019, 3, 4, 5, 6, 7, DateTimeKind.Utc),
+            IsSelected = true,
+        };
+        var bundle = CredentialArchive.Serialize([incoming], Passphrase);
+
+        var conflictSeen = 0;
+        var result = await new CredentialPortabilityService(targetManager)
+            .ImportAsync(bundle, Passphrase, (inc, existing) =>
+            {
+                conflictSeen++;
+                Assert.Equal("prod", inc.AccountName);
+                Assert.Equal("{\"k\":\"OLD\"}", existing.CredentialData);
+                return ConflictResolution.Overwrite;
+            });
+
+        Assert.Equal(1, conflictSeen);
+        Assert.Equal(1, result.Overwritten);
+        Assert.Equal(0, result.Added);
+
+        var stored = await SingleExportAsync(targetManager);
+        Assert.Equal(incoming.AccountId, stored.AccountId);
+        Assert.Equal("{\"k\":\"NEW\"}", stored.CredentialData);
+        Assert.True(stored.IsSelected);
+    }
+
+    [Fact]
+    public async Task Import_AddsWhenNoConflict_WithoutInvokingResolver()
+    {
+        using var target = new TempDir();
+        var targetManager = NewManager(target.Path);
+        _ = await targetManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"a\"}");
+
+        var incoming = new CredentialExport
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            AccountName = "sandbox", // different name → no collision
+            ProviderName = "Adobe",
+            Environment = "Sandbox",
+            CredentialData = "{\"k\":\"b\"}",
+            CreatedAt = new DateTime(2022, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            IsSelected = false,
+        };
+        var bundle = CredentialArchive.Serialize([incoming], Passphrase);
+
+        var result = await new CredentialPortabilityService(targetManager)
+            .ImportAsync(bundle, Passphrase, (_, _) => throw new Xunit.Sdk.XunitException("resolver must not run without a conflict"));
+
+        Assert.Equal(1, result.Added);
+        Assert.Equal(0, result.Overwritten);
+        Assert.Equal(2, (await targetManager.ExportCredentialsAsync()).Count);
+    }
+}


### PR DESCRIPTION
## What & why

On-disk credential ciphertext is **machine-bound** (each backend keys off machine/user identity or an OS secret store), so the files can't be copied between machines. This adds `accounts export` / `accounts import`: export reads every credential *decrypted* and re-encrypts the whole set into one portable, **passphrase-encrypted** archive; import decrypts it and re-stores each credential through the normal backend path, re-protecting it under the destination machine's key/store.

## ⚠️ Breaking change

`ICredentialManager` gains two members — `ExportCredentialsAsync()` and `RestoreCredentialAsync(CredentialExport)` — plus the new public `CredentialExport` record (full-fidelity, carries the *decrypted* payload). External implementations must add both members. **This warrants a major version bump** and a matching update to the downstream Providers packages' capped `[0.7.1,1.0.0)` range. Version left at `0.7.1` for a manual bump.

## Highlights

- **All three backends** implement both members natively. AccountId + selection preserved everywhere; `CreatedAt` preserved on file + libsecret (macOS Keychain assigns its own creation date — documented, cosmetic only).
- **`CredentialArchive`** — passphrase AES-256-GCM over PBKDF2-HMAC-SHA256 (600k iterations, random per-export salt), reusing the existing crypto convention; key/plaintext buffers zeroed after use.
- **`CredentialPortabilityService`** — backend-agnostic orchestration above the interface, with an injected conflict resolver (prompt-free and unit-testable).
- **Passphrase-only** (prompted+confirmed, or `--passphrase-env` for scripts); archive written `0600` on Unix. Import matches on *(provider, account name, environment)* and prompts per conflict, with `--on-conflict skip|overwrite` for non-interactive runs.

## Tests / verification

- Archive crypto (round-trip, wrong passphrase, tamper detection, bad input, unsupported version), the service (round-trip incl. `CreatedAt`, idempotent skip, overwrite, no-conflict add), and direct Export/Restore contract tests on all three backends.
- Clean Debug + Release build on `net8.0` and `net10.0` (0 warnings under `TreatWarningsAsErrors`); **326/326 tests pass** on both TFMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)