### PR TITLE
test: harden flaky secret-store delete assertions

### DIFF
--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelper.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelper.cs
@@ -1,0 +1,41 @@
+namespace NextIteration.SpectreConsole.Auth.Tests.Infrastructure;
+
+/// <summary>
+/// Small polling helper for the OS-native secret-store tests. A just-completed
+/// <c>AddCredentialAsync</c> against the macOS Keychain or the Linux Secret
+/// Service is not always immediately visible to the next lookup when two test
+/// processes (multi-targeting) hit the same store concurrently — so an
+/// add-then-delete can see the delete's lookup miss the item and return false.
+/// That is a store-visibility timing artifact of the tests running side by
+/// side, not a defect in the manager, so it is closed here rather than by
+/// making the production delete path slower.
+/// </summary>
+internal static class RetryHelper
+{
+    /// <summary>
+    /// Invokes <paramref name="action"/> until it returns <see langword="true"/>
+    /// or the attempts are exhausted, pausing <paramref name="delayMs"/> between
+    /// tries. Returns the last result — <see langword="false"/> only if every
+    /// attempt failed, so a genuinely-absent target still fails the assertion.
+    /// </summary>
+    internal static async Task<bool> UntilTrueAsync(
+        Func<Task<bool>> action,
+        int maxAttempts = 20,
+        int delayMs = 25)
+    {
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            if (await action())
+            {
+                return true;
+            }
+
+            if (attempt < maxAttempts)
+            {
+                await Task.Delay(delayMs);
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.Versioning;
 using NextIteration.SpectreConsole.Auth.Commands;
 using NextIteration.SpectreConsole.Auth.Persistence;
 using NextIteration.SpectreConsole.Auth.Persistence.Keychain;
+using NextIteration.SpectreConsole.Auth.Tests.Infrastructure;
 
 using Xunit;
 
@@ -96,7 +97,7 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         var exported = Assert.Single(await manager.ExportCredentialsAsync());
 
         // Simulate an import: drop it, then restore from the export record.
-        Assert.True(await manager.DeleteCredentialAsync(id));
+        Assert.True(await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(id)));
         await manager.RestoreCredentialAsync(exported);
 
         var restored = Assert.Single(await manager.ExportCredentialsAsync());
@@ -247,7 +248,7 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         var manager = NewManager();
         var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
 
-        var deleted = await manager.DeleteCredentialAsync(accountId);
+        var deleted = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
         Assert.True(deleted);
@@ -262,7 +263,7 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
         _ = await manager.SelectCredentialAsync(accountId);
 
-        _ = await manager.DeleteCredentialAsync(accountId);
+        _ = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
 
         Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
     }

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.Versioning;
 using NextIteration.SpectreConsole.Auth.Commands;
 using NextIteration.SpectreConsole.Auth.Persistence;
 using NextIteration.SpectreConsole.Auth.Persistence.Libsecret;
+using NextIteration.SpectreConsole.Auth.Tests.Infrastructure;
 
 using Xunit;
 
@@ -131,7 +132,7 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
         var exported = Assert.Single(await manager.ExportCredentialsAsync());
 
         // Simulate an import: drop it, then restore from the export record.
-        Assert.True(await manager.DeleteCredentialAsync(id));
+        Assert.True(await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(id)));
         await manager.RestoreCredentialAsync(exported);
 
         var restored = Assert.Single(await manager.ExportCredentialsAsync());
@@ -281,7 +282,7 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
         var manager = NewManager();
         var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
 
-        var deleted = await manager.DeleteCredentialAsync(accountId);
+        var deleted = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
         var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
 
         Assert.True(deleted);
@@ -296,7 +297,7 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
         var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
         _ = await manager.SelectCredentialAsync(accountId);
 
-        _ = await manager.DeleteCredentialAsync(accountId);
+        _ = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
 
         Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
     }


### PR DESCRIPTION
First of a short series clearing out `TODO.md`.

## Problem

`KeychainCredentialManagerTests.DeleteCredentialAsync_RemovesCredential` flaked on macOS CI (documented in `TODO.md`): a just-completed `AddCredentialAsync` isn't always visible to the delete's lookup when the two multi-targeted test processes hit the same login keychain concurrently, so `DeleteCredentialAsync` returns `false` and `Assert.True(deleted)` fails. A flaky security-critical test trains people to ignore red. The libsecret suite shares the same shape.

## Fix

Test-side, not production-side — penalizing the real delete path for a test-only add-then-delete race under concurrent access would be the wrong tradeoff. Adds `Infrastructure/RetryHelper.UntilTrueAsync` (bounded ~500ms poll) and routes the delete-result / post-delete-state assertions in **both** the Keychain and libsecret suites through it. A genuinely-absent target still returns `false`, so the assertions keep their meaning.

## Notes

- Resolves the flaky-test entry in `TODO.md`; the file is deleted in the final cleanup PR of this series.
- Verified: 326/326 pass on net8.0 + net10.0 locally (libsecret leg runs for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)