### PR TITLE
feat: harden LocalFileCredentialEncryption (keystore versioning + zero-on-dispose)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     on the file and libsecret backends. On the macOS Keychain the creation timestamp is
     assigned by the OS, so a restored item gets a fresh one (cosmetic only).
 
+- **`LocalFileCredentialEncryption` now zeroes key material on dispose.** The class
+  implements `IDisposable` and, when disposed, `CryptographicOperations.ZeroMemory`s the
+  in-memory data key and any caller-supplied entropy so a heap dump taken after shutdown
+  doesn't expose them. Registered as a DI singleton (the default), this runs at container
+  disposal — no consumer code change required.
+
 ### Changed
+
+- **`.keystore` files now carry a format header (magic + 1-byte version).** A future
+  KDF/format change can now be detected and rejected with a clear "unsupported keystore
+  format version" error instead of surfacing as an opaque integrity-check failure.
+  Keystores written by earlier (headerless) versions are still read; **note the reverse is
+  not true** — a keystore written by this version is not readable by pre-header library
+  versions. For consistency, `EncryptAsync` now lets an already-actionable
+  `InvalidOperationException` (such as this one) propagate as-is rather than re-wrapping it
+  as a generic encrypt failure, matching `DecryptAsync`.
 
 - **BREAKING: `ICredentialManager` gains two members** — `ExportCredentialsAsync()` and
   `RestoreCredentialAsync(CredentialExport)`, plus the new public `CredentialExport` record

--- a/src/NextIteration.SpectreConsole.Auth/Encryption/LocalFileCredentialEncryption.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Encryption/LocalFileCredentialEncryption.cs
@@ -34,14 +34,38 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
     /// For the strongest protection, use DPAPI (on Windows) or a platform
     /// keychain (macOS Keychain, Linux libsecret) instead.
     /// </para>
+    /// <para>
+    /// The <c>.keystore</c> file written by this version carries a format
+    /// header so future changes can be detected and rejected cleanly. Legacy
+    /// headerless keystores are still read; keystores written by this version
+    /// are not readable by pre-header library versions.
+    /// </para>
+    /// <para>
+    /// Implements <see cref="IDisposable"/>: disposing zeroes the in-memory
+    /// data key and any caller-supplied entropy. When registered in DI as a
+    /// singleton (the default), this happens at container disposal.
+    /// </para>
     /// </remarks>
-    public class LocalFileCredentialEncryption : ICredentialEncryption
+    public class LocalFileCredentialEncryption : ICredentialEncryption, IDisposable
     {
         // AES-GCM standard sizes. 12-byte nonce and 16-byte tag are the
         // recommended defaults and the values NIST SP 800-38D specifies.
         private const int NonceSize = 12;
         private const int TagSize = 16;
         private const int KeySize = 32; // AES-256
+
+        // Keystore file format header. A keystore written by this version is
+        // prefixed with this magic and a one-byte format version, so a future
+        // KDF/format change can be detected and rejected with a clear
+        // "unsupported format" error instead of surfacing as an opaque
+        // integrity-check failure. Keystores written by earlier versions have
+        // no header (they begin with a random 12-byte nonce); those are still
+        // read, since the 8-byte magic can't plausibly collide with a random
+        // nonce prefix (~2^-64). Note the reverse is not true: a keystore
+        // written by this version is not readable by pre-header library
+        // versions.
+        private static readonly byte[] KeystoreMagic = "NISCA-KS"u8.ToArray();
+        private const byte KeystoreFormatVersion = 1;
 
         // PBKDF2-HMAC-SHA256 iteration count. OWASP 2023 guidance is
         // 600,000. In default mode (no caller entropy) iterations provide
@@ -65,6 +89,7 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
         // want to fail every call the same way, not re-try and succeed on
         // some while failing on others.
         private readonly Lazy<Task<byte[]>> _dataKey;
+        private bool _disposed;
 
         /// <summary>
         /// Creates the encryption implementation backed by a keystore file
@@ -116,6 +141,14 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
                 var key = await GetOrCreateKeyAsync().ConfigureAwait(false);
                 var plainBytes = Encoding.UTF8.GetBytes(plainText);
                 return Convert.ToBase64String(EncryptWithGcm(key, plainBytes));
+            }
+            catch (InvalidOperationException)
+            {
+                // An already-actionable message (e.g. an unsupported keystore
+                // format surfaced during lazy key load) should propagate as-is
+                // rather than being re-wrapped as a generic encrypt failure.
+                // Mirrors the same passthrough in DecryptAsync.
+                throw;
             }
             catch (Exception ex)
             {
@@ -173,9 +206,39 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
                 await CreateKeyFileAsync().ConfigureAwait(false);
             }
 
-            var encryptedKey = await File.ReadAllBytesAsync(_keyFile).ConfigureAwait(false);
+            var stored = await File.ReadAllBytesAsync(_keyFile).ConfigureAwait(false);
+            var encryptedKey = StripKeystoreHeader(stored);
             var kek = DeriveKeyEncryptionKey();
             return DecryptWithGcm(kek, encryptedKey);
+        }
+
+        /// <summary>
+        /// Returns the AES-GCM payload of a keystore file, skipping the format
+        /// header when present. A keystore written by this version begins with
+        /// <see cref="KeystoreMagic"/> followed by a one-byte version; a legacy
+        /// keystore has no header and is returned unchanged. Throws when the
+        /// header is present but its version is not understood, so a keystore
+        /// from a newer library fails clearly rather than as an opaque
+        /// integrity error.
+        /// </summary>
+        private static byte[] StripKeystoreHeader(byte[] stored)
+        {
+            var headerLength = KeystoreMagic.Length + 1;
+            if (stored.Length < headerLength ||
+                !stored.AsSpan(0, KeystoreMagic.Length).SequenceEqual(KeystoreMagic))
+            {
+                // No recognisable header — treat as a legacy headerless keystore.
+                return stored;
+            }
+
+            var version = stored[KeystoreMagic.Length];
+            if (version != KeystoreFormatVersion)
+            {
+                throw new InvalidOperationException(
+                    $"Unsupported keystore format version {version}. This build supports version {KeystoreFormatVersion}; the keystore was likely written by a newer version of the library.");
+            }
+
+            return stored[headerLength..];
         }
 
         private async Task CreateKeyFileAsync()
@@ -183,6 +246,14 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
             var key = RandomNumberGenerator.GetBytes(KeySize);
             var kek = DeriveKeyEncryptionKey();
             var encryptedKey = EncryptWithGcm(kek, key);
+
+            // Frame the payload with the format header so the version is
+            // self-describing on the next read.
+            var framed = new byte[KeystoreMagic.Length + 1 + encryptedKey.Length];
+            Buffer.BlockCopy(KeystoreMagic, 0, framed, 0, KeystoreMagic.Length);
+            framed[KeystoreMagic.Length] = KeystoreFormatVersion;
+            Buffer.BlockCopy(encryptedKey, 0, framed, KeystoreMagic.Length + 1, encryptedKey.Length);
+            encryptedKey = framed;
 
             var directory = Path.GetDirectoryName(_keyFile);
             if (!string.IsNullOrEmpty(directory))
@@ -266,6 +337,49 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
             using var aes = new AesGcm(key, TagSize);
             aes.Decrypt(nonce, ciphertext, tag, plaintext);
             return plaintext;
+        }
+
+        /// <summary>
+        /// Zeroes the in-memory data key and caller-supplied entropy. Safe to
+        /// call more than once.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Core disposal. Overriders should call the base implementation so the
+        /// key material is still cleared.
+        /// </summary>
+        /// <param name="disposing">
+        /// <see langword="true"/> when called from <see cref="Dispose()"/>.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                if (_callerEntropy is not null)
+                {
+                    CryptographicOperations.ZeroMemory(_callerEntropy);
+                }
+
+                // Only zero the cached key if it was actually derived and
+                // completed successfully; touching a faulted/pending Task's
+                // Result would throw or block.
+                if (_dataKey.IsValueCreated && _dataKey.Value.IsCompletedSuccessfully)
+                {
+                    CryptographicOperations.ZeroMemory(_dataKey.Value.Result);
+                }
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
@@ -181,7 +181,7 @@ public sealed class LocalFileCredentialEncryptionTests
     {
         using var temp = new TempDir();
         var encryption = new LocalFileCredentialEncryption(temp.Path);
-        var keystorePath = Path.Combine(temp.Path, ".keystore");
+        var keystorePath = Path.Join(temp.Path, ".keystore");
 
         Assert.False(File.Exists(keystorePath), "keystore should not exist before first encrypt/decrypt");
 
@@ -257,7 +257,7 @@ public sealed class LocalFileCredentialEncryptionTests
         // Delete the keystore and create a new instance with a different
         // entropy — the new instance will write a fresh keystore and fail
         // to decrypt the old ciphertext.
-        File.Delete(Path.Combine(temp.Path, ".keystore"));
+        File.Delete(Path.Join(temp.Path, ".keystore"));
         var entropyB = "entropy-bravo"u8.ToArray();
         var wrongEntropy = new LocalFileCredentialEncryption(temp.Path, entropyB);
 
@@ -354,7 +354,7 @@ public sealed class LocalFileCredentialEncryptionTests
 
         _ = await encryption.EncryptAsync("trigger keystore creation");
 
-        var bytes = await File.ReadAllBytesAsync(Path.Combine(temp.Path, ".keystore"), TestContext.Current.CancellationToken);
+        var bytes = await File.ReadAllBytesAsync(Path.Join(temp.Path, ".keystore"), TestContext.Current.CancellationToken);
         Assert.True(bytes.Length > KeystoreMagic.Length + 1);
         Assert.Equal(KeystoreMagic, bytes[..KeystoreMagic.Length]);
         Assert.Equal(1, bytes[KeystoreMagic.Length]); // format version
@@ -364,7 +364,7 @@ public sealed class LocalFileCredentialEncryptionTests
     public async Task Keystore_LegacyHeaderless_IsStillReadable()
     {
         using var temp = new TempDir();
-        var keystorePath = Path.Combine(temp.Path, ".keystore");
+        var keystorePath = Path.Join(temp.Path, ".keystore");
 
         // Produce a keystore, then strip its header to reconstruct the legacy
         // headerless on-disk shape a pre-header library version would have
@@ -384,7 +384,7 @@ public sealed class LocalFileCredentialEncryptionTests
     public async Task Keystore_UnknownFormatVersion_ThrowsClearError()
     {
         using var temp = new TempDir();
-        var keystorePath = Path.Combine(temp.Path, ".keystore");
+        var keystorePath = Path.Join(temp.Path, ".keystore");
 
         var writer = new LocalFileCredentialEncryption(temp.Path);
         _ = await writer.EncryptAsync("anything");

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Security.Cryptography;
 
 using NextIteration.SpectreConsole.Auth.Encryption;
@@ -337,6 +338,96 @@ public sealed class LocalFileCredentialEncryptionTests
         }
 
         Assert.Equal("immutable entropy", await encryption.DecryptAsync(cipher));
+    }
+
+    // =========================
+    // Keystore format versioning
+    // =========================
+
+    private static readonly byte[] KeystoreMagic = "NISCA-KS"u8.ToArray();
+
+    [Fact]
+    public async Task Keystore_WrittenByThisVersion_CarriesFormatHeader()
+    {
+        using var temp = new TempDir();
+        var encryption = new LocalFileCredentialEncryption(temp.Path);
+
+        _ = await encryption.EncryptAsync("trigger keystore creation");
+
+        var bytes = await File.ReadAllBytesAsync(Path.Combine(temp.Path, ".keystore"), TestContext.Current.CancellationToken);
+        Assert.True(bytes.Length > KeystoreMagic.Length + 1);
+        Assert.Equal(KeystoreMagic, bytes[..KeystoreMagic.Length]);
+        Assert.Equal(1, bytes[KeystoreMagic.Length]); // format version
+    }
+
+    [Fact]
+    public async Task Keystore_LegacyHeaderless_IsStillReadable()
+    {
+        using var temp = new TempDir();
+        var keystorePath = Path.Combine(temp.Path, ".keystore");
+
+        // Produce a keystore, then strip its header to reconstruct the legacy
+        // headerless on-disk shape a pre-header library version would have
+        // written. A fresh instance must still read ciphertext bound to it.
+        var writer = new LocalFileCredentialEncryption(temp.Path);
+        var cipher = await writer.EncryptAsync("bound to a legacy keystore");
+
+        var framed = await File.ReadAllBytesAsync(keystorePath, TestContext.Current.CancellationToken);
+        var legacy = framed[(KeystoreMagic.Length + 1)..];
+        await File.WriteAllBytesAsync(keystorePath, legacy, TestContext.Current.CancellationToken);
+
+        var reader = new LocalFileCredentialEncryption(temp.Path);
+        Assert.Equal("bound to a legacy keystore", await reader.DecryptAsync(cipher));
+    }
+
+    [Fact]
+    public async Task Keystore_UnknownFormatVersion_ThrowsClearError()
+    {
+        using var temp = new TempDir();
+        var keystorePath = Path.Combine(temp.Path, ".keystore");
+
+        var writer = new LocalFileCredentialEncryption(temp.Path);
+        _ = await writer.EncryptAsync("anything");
+
+        // Bump the version byte to one this build doesn't understand.
+        var bytes = await File.ReadAllBytesAsync(keystorePath, TestContext.Current.CancellationToken);
+        bytes[KeystoreMagic.Length] = 0xFF;
+        await File.WriteAllBytesAsync(keystorePath, bytes, TestContext.Current.CancellationToken);
+
+        var reader = new LocalFileCredentialEncryption(temp.Path);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => reader.EncryptAsync("triggers keystore load"));
+        Assert.Contains("version", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // =========================
+    // Zero-on-dispose
+    // =========================
+
+    [Fact]
+    public async Task Dispose_ZeroesKeyMaterial_AndIsIdempotent()
+    {
+        using var temp = new TempDir();
+        var entropy = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        var encryption = new LocalFileCredentialEncryption(temp.Path, entropy);
+
+        _ = await encryption.EncryptAsync("ensure the data key is derived");
+
+        encryption.Dispose();
+        encryption.Dispose(); // idempotent — must not throw
+
+        // The internal defensive copy of the entropy is zeroed.
+        var entropyField = typeof(LocalFileCredentialEncryption)
+            .GetField("_callerEntropy", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var storedEntropy = (byte[])entropyField.GetValue(encryption)!;
+        Assert.All(storedEntropy, b => Assert.Equal(0, b));
+
+        // The cached data key is zeroed too.
+        var dataKeyField = typeof(LocalFileCredentialEncryption)
+            .GetField("_dataKey", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var lazy = (Lazy<Task<byte[]>>)dataKeyField.GetValue(encryption)!;
+        Assert.True(lazy.IsValueCreated);
+        Assert.All(await lazy.Value, b => Assert.Equal(0, b));
     }
 
     [Fact]

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
@@ -409,7 +409,9 @@ public sealed class LocalFileCredentialEncryptionTests
     {
         using var temp = new TempDir();
         var entropy = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
-        var encryption = new LocalFileCredentialEncryption(temp.Path, entropy);
+        // `using` guarantees disposal even if EncryptAsync throws; the explicit
+        // Dispose() calls below still exercise the zeroing + idempotency.
+        using var encryption = new LocalFileCredentialEncryption(temp.Path, entropy);
 
         _ = await encryption.EncryptAsync("ensure the data key is derived");
 


### PR DESCRIPTION
Second in the series clearing out `TODO.md` — closes both "Future hardening ideas" under the `LocalFileCredentialEncryption` section.

## Keystore format versioning
The `.keystore` file now begins with an 8-byte magic + 1-byte format version. A future KDF/format change can be detected and rejected with a clear **"unsupported keystore format version"** error instead of an opaque integrity-check failure.
- Legacy headerless keystores are still read (the 8-byte magic can't plausibly collide with a random nonce prefix, ~2^-64).
- **Forward-incompat:** a keystore written by this version is *not* readable by pre-header library versions.
- For consistency, `EncryptAsync` now lets an already-actionable `InvalidOperationException` propagate as-is (matching `DecryptAsync`), so the clear message reaches the user even on the non-verbose path.

## Zero-on-dispose
`LocalFileCredentialEncryption` implements `IDisposable` and zeroes the in-memory data key + caller-supplied entropy (`CryptographicOperations.ZeroMemory`) on disposal, so a post-shutdown heap dump doesn't expose them. As the default DI singleton, this runs at container disposal — no consumer change needed.

## Tests / verification
New tests: header presence on new keystores, legacy headerless read, unsupported-version error, dispose zeroing (idempotent). 334/334 pass on net8.0 + net10.0 locally; clean Release build (package validation incl. the new `IDisposable`).

`TODO.md` itself is removed in the final cleanup PR of this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)