### PR TITLE
test: harden read-after-write in secret-store export/restore tests

### DIFF
--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelper.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelper.cs
@@ -38,4 +38,29 @@ internal static class RetryHelper
 
         return false;
     }
+
+    /// <summary>
+    /// Invokes <paramref name="action"/> until its result satisfies
+    /// <paramref name="predicate"/> or the attempts are exhausted, and returns
+    /// that result. Used for read-after-write against the OS secret stores,
+    /// where a just-completed add isn't always immediately visible to the next
+    /// query under concurrent (multi-targeted) test runs. Returns the last
+    /// result even if the predicate never held, so the caller's assertion still
+    /// reports the real failure rather than a timeout.
+    /// </summary>
+    internal static async Task<T> UntilAsync<T>(
+        Func<Task<T>> action,
+        Func<T, bool> predicate,
+        int maxAttempts = 20,
+        int delayMs = 25)
+    {
+        var result = await action();
+        for (var attempt = 1; !predicate(result) && attempt < maxAttempts; attempt++)
+        {
+            await Task.Delay(delayMs);
+            result = await action();
+        }
+
+        return result;
+    }
 }

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -76,7 +76,7 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
         Assert.True(await manager.SelectCredentialAsync(id));
 
-        var adobe = Assert.Single(await manager.ExportCredentialsAsync());
+        var adobe = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
         Assert.Equal(id, adobe.AccountId);
         Assert.Equal("prod", adobe.AccountName);
         Assert.Equal("Adobe", adobe.ProviderName);
@@ -94,13 +94,13 @@ public sealed class KeychainCredentialManagerTests : IDisposable
         var manager = NewManager();
         var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
         _ = await manager.SelectCredentialAsync(id);
-        var exported = Assert.Single(await manager.ExportCredentialsAsync());
+        var exported = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
 
         // Simulate an import: drop it, then restore from the export record.
         Assert.True(await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(id)));
         await manager.RestoreCredentialAsync(exported);
 
-        var restored = Assert.Single(await manager.ExportCredentialsAsync());
+        var restored = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
         Assert.Equal(id, restored.AccountId);
         Assert.True(restored.IsSelected);
         Assert.Equal("{\"apiKey\":\"secret\"}", await manager.GetSelectedCredentialAsync("Adobe"));

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -113,7 +113,7 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
         var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
         Assert.True(await manager.SelectCredentialAsync(id));
 
-        var adobe = Assert.Single(await manager.ExportCredentialsAsync());
+        var adobe = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
         Assert.Equal(id, adobe.AccountId);
         Assert.Equal("prod", adobe.AccountName);
         Assert.Equal("Adobe", adobe.ProviderName);
@@ -129,13 +129,13 @@ public sealed class LibsecretCredentialManagerTests : IDisposable
         var manager = NewManager();
         var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
         _ = await manager.SelectCredentialAsync(id);
-        var exported = Assert.Single(await manager.ExportCredentialsAsync());
+        var exported = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
 
         // Simulate an import: drop it, then restore from the export record.
         Assert.True(await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(id)));
         await manager.RestoreCredentialAsync(exported);
 
-        var restored = Assert.Single(await manager.ExportCredentialsAsync());
+        var restored = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
         Assert.Equal(id, restored.AccountId);
         Assert.Equal(exported.CreatedAt, restored.CreatedAt); // libsecret preserves it via attribute
         Assert.True(restored.IsSelected);


### PR DESCRIPTION
Surfaced by PR #27's macOS leg: `KeychainCredentialManagerTests.RestoreCredentialAsync_PreservesAccountIdAndSelection` failed with `Assert.Single() Failure: The collection was empty`.

## Cause
The Export/Restore tests read back via `Assert.Single(await ExportCredentialsAsync())` right after an `Add`/`Restore`. `ExportCredentialsAsync` enumerates the whole app (`QueryAllItemsForApp`), and a just-completed add isn't always visible to that query yet when the two multi-targeted test processes hit one login keychain concurrently. Same add-visibility race we already fixed for the *delete* assertions — just not applied to these read-after-write points.

## Fix (test-only)
- Add `RetryHelper.UntilAsync<T>(action, predicate)`.
- Wrap the six `ExportCredentialsAsync` read-backs (Keychain ×3, libsecret ×3) so they poll until the item is visible. Returns the last result, so a genuine failure still fails the assertion rather than timing out silently.

Independent of PR #27 (editorconfig) — this is a pre-existing latent flake on `main`. Once merged, I'll rebase #27 on top so its macOS leg includes the hardening.

Verified: 49/49 Keychain+libsecret tests pass locally (libsecret real, Keychain vacuous on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)