### PR TITLE
fix: close the add-then-select visibility race in Keychain/libsecret backends

### DIFF
--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
@@ -74,7 +74,38 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
             };
 
             AddItem(attrs);
+
+            // SecItemAdd can lag SecItemCopyMatching visibility under concurrent
+            // keychain access, so a caller doing add-then-select/delete — e.g.
+            // `accounts add` offering to activate the new credential — can race
+            // the item's own appearance and see the follow-up lookup miss it.
+            // Confirm the item is queryable before returning so that can't happen.
+            ConfirmItemVisible(attrs.Service, accountId);
+
             return Task.FromResult(accountId);
+        }
+
+        /// <summary>
+        /// Polls for a just-added item to become visible to
+        /// <c>SecItemCopyMatching</c>, closing the brief add-visibility window.
+        /// Best-effort: returns after a bounded wait even if the item never
+        /// appears, leaving any genuine failure to the caller's own lookup.
+        /// </summary>
+        private static void ConfirmItemVisible(string service, string account)
+        {
+            const int maxAttempts = 20;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                if (QuerySingleItem(service, account, includeData: false) is not null)
+                {
+                    return;
+                }
+
+                if (attempt < maxAttempts)
+                {
+                    Thread.Sleep(25);
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
@@ -91,7 +91,37 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             var label = $"{_appIdentifier}: {providerName}/{accountName}";
 
             StoreItem(attrs, label, credentialData);
+
+            // A just-stored Secret Service item isn't always immediately visible
+            // to a follow-up search under concurrent access, so a caller doing
+            // add-then-select/delete can race the item's appearance. Confirm it's
+            // queryable before returning so that can't happen.
+            ConfirmItemVisible(providerName, accountId);
+
             return Task.FromResult(accountId);
+        }
+
+        /// <summary>
+        /// Polls for a just-stored item to become visible to a Secret Service
+        /// lookup, closing the brief store-visibility window. Best-effort:
+        /// returns after a bounded wait even if the item never appears, leaving
+        /// any genuine failure to the caller's own lookup.
+        /// </summary>
+        private void ConfirmItemVisible(string providerName, string accountId)
+        {
+            const int maxAttempts = 20;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                if (LookupCredentialByAccountId(providerName, accountId) is not null)
+                {
+                    return;
+                }
+
+                if (attempt < maxAttempts)
+                {
+                    Thread.Sleep(25);
+                }
+            }
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## The bug
`AddCredentialAsync` returned as soon as the OS store accepted the item, but a just-added item isn't always immediately visible to a follow-up query on the macOS Keychain (`SecItemAdd` → `SecItemCopyMatching` lag), and occasionally the Linux Secret Service, under concurrent access. So a caller doing **add-then-select/delete** — which `AddCredentialCommand` does in production when it offers to activate the new credential — could race the item's own appearance and have the follow-up lookup miss it, returning `false`.

This is the same race we'd been hardening test-side (delete/export/select assertions); it's a genuine latent bug in the experimental backends, not just a test artifact.

## The fix
Both backends now **confirm the item is queryable before `AddCredentialAsync` returns** (a bounded ~500ms poll of the by-account lookup). Best-effort: it returns after the bounded wait regardless, leaving any genuine failure to the caller's own lookup. The file backend has no such window and is untouched.

## Notes
- Fixes the root cause behind the earlier test-side retry hardening (kept as defence-in-depth).
- Experimental backends only.

Verified: clean build (flag on, both TFMs); 82/82 libsecret + file tests pass locally (libsecret exercises the new confirm-visible path for real).

🤖 Generated with [Claude Code](https://claude.com/claude-code)