### PR TITLE
chore: exclude the two P/Invoke audit queries in codeql.yml (Standards §4.4)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,10 +49,24 @@ jobs:
           # Analyse source only. obj/ and bin/ hold generated and compiled
           # output — e.g. the xUnit auto-generated entry point — so findings
           # there are noise against code no human maintains.
+          #
+          # query-filters excludes the two audit queries that fire on every
+          # P/Invoke declaration and call site (cs/unmanaged-code,
+          # cs/call-to-unmanaged-code). Native-backend packages (Keychain,
+          # libsecret, DPAPI) exist to call unmanaged code, so these are pure
+          # noise there and non-native repos have no P/Invoke for them to hit.
+          # This excludes ONLY those two queries — every other
+          # security-and-quality query still runs on the interop files, so no
+          # real finding is lost (STANDARD.md 4.4).
           config: |
             paths-ignore:
               - "**/obj/**"
               - "**/bin/**"
+            query-filters:
+              - exclude:
+                  id: cs/unmanaged-code
+              - exclude:
+                  id: cs/call-to-unmanaged-code
 
       # Explicit build rather than autobuild: these repos multi-target, and
       # autobuild has picked a single TFM in the past, silently analysing half

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CodeQL now excludes the two P/Invoke audit queries at the config level** (NextIteration.Standards
+  §4.4). A `query-filters` block in `codeql.yml` excludes exactly `cs/unmanaged-code` and
+  `cs/call-to-unmanaged-code` — audit queries that fire on every P/Invoke into Keychain,
+  libsecret, and DPAPI and that no code change can resolve (native interop is the point).
+  Every other `security-and-quality` query still runs on the interop files, so no real
+  finding is lost. This replaces the per-alert *won't fix* dismissals, which reopened
+  whenever a reformat shifted a line number.
+
 - **Enabled `EnforceCodeStyleInBuild`** (NextIteration.Standards §1.2.1, now a `MUST`). The
   canonical `.editorconfig`'s gated rules now fail the build instead of merely showing in
   the IDE, so the house style is enforced. Bringing the code green under the flag was a


### PR DESCRIPTION
Adopts the revised canonical `codeql.yml` from **[NextIteration.Standards#18](https://github.com/StuartMeeks/NextIteration.Standards/pull/18)** — a `query-filters` block excluding exactly `cs/unmanaged-code` and `cs/call-to-unmanaged-code`.

These are **audit** queries that fire on every P/Invoke into the Keychain/libsecret/DPAPI backends. No code change resolves them — native interop is the whole point of these backends. Excluding exactly those two is a genuine config fix (every other `security-and-quality` query still runs on the interop files, so nothing real is lost), and it replaces the per-alert *won't fix* dismissals that kept **reopening whenever a reformat shifted a line number** (twice this week).

After this merges, the previously-dismissed P/Invoke alerts simply won't be produced.

> Depends on standards PR #18 for full §3.0.1 conformance (this repo's `codeql.yml` now matches the *proposed* template). Independent of it functionally — this repo's CI just stops emitting the two queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)