### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-08-21
+
+First stable release. Headline: whole-store **export/import** to move credentials
+between machines. **Breaking:** `ICredentialManager` gains `ExportCredentialsAsync` and
+`RestoreCredentialAsync` plus the `CredentialExport` record — any external implementation
+must add both members.
+
 ### Added
 
 - **`accounts export` and `accounts import` — move your whole credential set between
@@ -388,6 +395,9 @@ Consumers needed a way to read a specific stored credential's secret at runtime 
 - SourceLink, deterministic builds, embedded symbols, published symbol packages.
 - `TreatWarningsAsErrors=true`, `AnalysisLevel=latest` — zero-warning public API.
 
+[Unreleased]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v1.0.0
+[0.7.1]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.7.1
 [0.7.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.7.0
 [0.6.3]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.3
 [0.6.2]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.6.2

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -12,7 +12,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>0.7.1</Version>
+		<Version>1.0.0</Version>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
 		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\packages</PackageOutputPath>


### PR DESCRIPTION
First stable release. 🎉

## Version
`<Version>` 0.7.1 → **1.0.0**.

## CHANGELOG
`[Unreleased]` cut to `## [1.0.0] — 2026-08-21`; added the `[Unreleased]`/`[1.0.0]` compare-and-tag link refs and backfilled the missing `[0.7.1]` one. A fresh empty `[Unreleased]` remains at the top.

## What 1.0.0 contains (from this cycle)
- **Added:** whole-store `accounts export` / `accounts import` (passphrase-encrypted, moves credentials between machines); zero-on-dispose for `LocalFileCredentialEncryption`.
- **⚠️ Breaking:** `ICredentialManager` gains `ExportCredentialsAsync()` and `RestoreCredentialAsync(CredentialExport)` plus the public `CredentialExport` record — external implementations must add both members.
- **Fixed:** flaky secret-store tests; a latent add-then-select visibility race in the Keychain/libsecret backends.
- **Changed (repo/standards):** keystore format header, CPM, canonical `.editorconfig` + `EnforceCodeStyleInBuild`, CodeQL merge gate + P/Invoke query-filter, code-quality alert cleanup.

## After this merges
Tag **`v1.0.0`** on `main` to trigger the `publish` job (trusted publishing to NuGet). The downstream **Providers** package caps this at `[0.7.1,1.0.0)`, so its cap needs raising + revalidating against 1.0.0 (separate repo).

Verified: clean Release build (0 warnings), 1.0.0 package produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)