### PR TITLE
chore: adopt buildless CodeQL analysis (Standards §4.4)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,23 +32,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: csharp
+          # build-mode: none analyses the C# source directly, without a build.
+          # It is load-bearing, not a convenience, for two reasons:
+          #
+          # 1. paths-ignore (below) only takes effect in this mode. When CodeQL
+          #    builds a compiled language, GitHub applies no path filter — every
+          #    file the compiler sees is analysed, obj/ included — so under the
+          #    explicit build this workflow used to run, paths-ignore was
+          #    silently inert and the xUnit auto-generated entry point in obj/
+          #    was analysed and flagged in every repo. Buildless extraction
+          #    honours the filter, so the exclusion the standard mandates
+          #    actually happens.
+          #
+          # 2. It reads the source across every target framework at once. These
+          #    repos multi-target, and autobuild has picked a single TFM in the
+          #    past, silently analysing half the code; the explicit build existed
+          #    to guard against that. Buildless extraction reads the source
+          #    itself, not one TFM's build output, so it covers all of it with no
+          #    build step to get wrong.
+          build-mode: none
           # security-and-quality is broader than the default security-extended;
           # these are small libraries, so the extra findings are affordable.
           queries: security-and-quality
           # Analyse source only. obj/ and bin/ hold generated and compiled
           # output — e.g. the xUnit auto-generated entry point — so findings
-          # there are noise against code no human maintains.
+          # there are noise against code no human maintains. Effective only
+          # under build-mode: none (above).
           #
           # query-filters excludes the two audit queries that fire on every
           # P/Invoke declaration and call site (cs/unmanaged-code,
@@ -67,15 +80,6 @@ jobs:
                   id: cs/unmanaged-code
               - exclude:
                   id: cs/call-to-unmanaged-code
-
-      # Explicit build rather than autobuild: these repos multi-target, and
-      # autobuild has picked a single TFM in the past, silently analysing half
-      # the code. Restore is separate so a restore failure is legible.
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CodeQL now analyses the C# source buildless** (NextIteration.Standards §4.4). The
+  `codeql.yml` init step moves to `build-mode: none` and the explicit `Setup .NET`,
+  `Restore`, and `Build` steps are dropped. This is load-bearing, not a simplification:
+  GitHub applies the `paths-ignore` filter *only* under buildless extraction — under a
+  compiled build every file the compiler sees is analysed, `obj/` included, so the
+  `**/obj/**` exclusion this repo already declared was silently inert and the xUnit
+  auto-generated entry point in `obj/` was being analysed. Buildless extraction also reads
+  every target framework at once, where autobuild could pick a single TFM and analyse half
+  the code. Adopts the revised canonical `codeql.yml` verbatim; no query coverage changes.
+
 ## [1.0.0] — 2026-08-21
 
 First stable release. Headline: whole-store **export/import** to move credentials


### PR DESCRIPTION
## What

Adopts the revised canonical `codeql.yml` (NextIteration.Standards PR #21) so this repo passes the standards audit's **3.0.1 (workflow content)** check, which was the only failing clause for Auth.

- Init step moves to `build-mode: none`.
- Drops the explicit `Setup .NET`, `Restore`, and `Build` steps.
- Result is byte-identical to `templates/.github/workflows/codeql.yml`.

## Why it's load-bearing, not a cleanup

GitHub applies the `paths-ignore` filter **only** under buildless extraction. Under a compiled build, every file the compiler sees is analysed — `obj/` included — so this repo's existing `**/obj/**` exclusion was silently inert and the xUnit auto-generated entry point in `obj/` was being analysed. Buildless extraction honours the filter, and also reads every target framework at once (autobuild could pick a single TFM and analyse half the code).

## Code scanning

Checked before and after: **no open code-scanning alerts**. The 30 `cs/call-to-unmanaged-code` findings are all `dismissed`, and their queries stay excluded via `query-filters` — genuine native interop, no code change resolves them. Query coverage (`security-and-quality`) is otherwise unchanged, so nothing real is dropped.

## Verification

`NextIteration.Standards/scripts/audit-drift.sh` — Auth's `3.0.1 workflow content` flips **FAIL → PASS**; all 32 clauses now green for Auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)