### PR TITLE
fix: resolve cs/dereferenced-value-may-be-null in ListCredentialsAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every target framework at once, where autobuild could pick a single TFM and analyse half
   the code. Adopts the revised canonical `codeql.yml` verbatim; no query coverage changes.
 
+- **Rewrote the provider-match guard in `FileCredentialManager.ListCredentialsAsync`**
+  from `credential?.ProviderName.Equals(…) == true` to an explicit
+  `credential is not null && …`. Behavior is identical, but the null state now flows into
+  the block body — which dereferences `credential` throughout — so both the compiler and
+  CodeQL can prove the accesses safe. Resolves the `cs/dereferenced-value-may-be-null`
+  alert the corrected buildless analysis surfaced (a genuine code fix, not a dismissal).
+
 ## [1.0.0] — 2026-08-21
 
 First stable release. Headline: whole-store **export/import** to move credentials

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
@@ -74,7 +74,11 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                     // Defensive re-check: the glob should only match this
                     // provider's files, but if a stray file sneaks in we want
                     // to ignore it rather than report a mis-attributed row.
-                    if (credential?.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase) == true)
+                    // `is not null` (rather than `?.… == true`) so the null
+                    // state flows into the block — the whole body dereferences
+                    // `credential`, and this lets the analyzer prove it safe.
+                    if (credential is not null &&
+                        credential.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase))
                     {
                         var isSelected = selections.TryGetValue($"{credential.ProviderName}", out var selectedId) &&
                                        selectedId.Equals(credential.AccountId, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## What

Resolves the one open code-scanning alert on `main` (`cs/dereferenced-value-may-be-null`, `FileCredentialManager.cs:79`) with a genuine code fix — no dismissal.

## Why it appeared now

The corrected buildless CodeQL analysis (#33) reads this file properly for the first time — the old compiled-build config had `paths-ignore` silently inert and analysed the wrong scope. The finding is real in the sense that CodeQL now sees it; the code itself was already safe.

## The fix

The provider-match guard was:

```csharp
if (credential?.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase) == true)
```

CodeQL's flow analysis doesn't narrow `credential` to non-null through the `?.… == true` idiom, so every dereference in the block body (`credential.ProviderName`, `.AccountId`, `.CredentialData`, …) reads as a potential null access. Rewritten to:

```csharp
if (credential is not null &&
    credential.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase))
```

Behavior is identical (a null `credential` still makes the guard false and skips the row), but the null state now flows into the block, so **both** the compiler and CodeQL can prove the accesses safe.

## Verification

- Build clean: 0 warnings (`TreatWarningsAsErrors` on).
- **334 tests pass** on `net8.0` and `net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)