### PR TITLE
release: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] — 2026-08-22
+
+Maintenance release. No API or behavior change for consumers: a behavior-identical
+hardening of an internal null-check in the file backend, plus a CI-only move to buildless
+CodeQL analysis. Safe drop-in over 1.0.0.
+
 ### Changed
 
 - **CodeQL now analyses the C# source buildless** (NextIteration.Standards §4.4). The
@@ -414,7 +420,8 @@ Consumers needed a way to read a specific stored credential's secret at runtime 
 - SourceLink, deterministic builds, embedded symbols, published symbol packages.
 - `TreatWarningsAsErrors=true`, `AnalysisLevel=latest` — zero-warning public API.
 
-[Unreleased]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v1.0.1
 [1.0.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v1.0.0
 [0.7.1]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.7.1
 [0.7.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v0.7.0

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -12,7 +12,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
 		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\packages</PackageOutputPath>


### PR DESCRIPTION
## Release 1.0.1

Maintenance release. **No consumer-facing API or behavior change** — safe drop-in over 1.0.0.

### Contents (cut from `[Unreleased]`)

- **`FileCredentialManager.ListCredentialsAsync` null-check hardening** — `credential?.… == true` → `credential is not null && …`. Behavior-identical; resolves the `cs/dereferenced-value-may-be-null` CodeQL alert with a genuine fix. *(Shipped code — this is why 1.0.1 is a real package.)*
- **Buildless CodeQL analysis** (Standards §4.4) — CI-only, not in the package.

### Release mechanics

- `<Version>` bumped 1.0.0 → 1.0.1.
- CHANGELOG `[Unreleased]` cut to `[1.0.1] — 2026-08-22`; compare/tag link refs updated.
- Local `dotnet build -c Release` packs `1.0.1.nupkg` + `.snupkg` clean (0 warnings, package validation OK).

After this merges, tagging `v1.0.1` triggers the `publish` job (OIDC → nuget.org).

🤖 Generated with [Claude Code](https://claude.com/claude-code)