### PR TITLE
docs: point Contributing at issues, not the retired TODO.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The README's Contributing section pointed at the retired `TODO.md`.** That file was
+  removed in #25 when its backlog moved to GitHub issues, but the change never updated the
+  README, so the link has been dead since 1.0.0. The same sentence also listed keystore
+  format versioning and zero-on-dispose for caller-supplied entropy as outstanding hardening
+  when both shipped in 1.0.0 — advertising finished work as a backlog. It now points at the
+  issue tracker and names only the two genuinely open items: ACL-scoped Keychain access (#18)
+  and libsecret KWallet validation (#19).
+
 ## [1.0.1] — 2026-08-22
 
 Maintenance release. No API or behavior change for consumers: a behavior-identical

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Everything else is transitive.
 
 ## Contributing
 
-Issues and PRs welcome. The [TODO](TODO.md) tracks outstanding hardening — keystore format versioning, zero-on-dispose for caller-supplied entropy, ACL-scoped Keychain access, and KWallet validation for the libsecret backend.
+Issues and PRs welcome. Outstanding hardening is tracked in [GitHub issues](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues) — currently ACL-scoped Keychain access ([#18](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues/18)) and KWallet validation for the libsecret backend ([#19](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues/19)).
 
 When contributing code, please keep the zero-warning, fully-documented public surface. `TreatWarningsAsErrors` is on for a reason.
 


### PR DESCRIPTION
## What changed

The README's Contributing section no longer links the retired `TODO.md`. It now points at the GitHub issue tracker and names only the two genuinely outstanding hardening items — ACL-scoped Keychain access (#18) and libsecret KWallet validation (#19).

## Why

Two separate bits of rot in one sentence:

1. **Dead link.** `TODO.md` was deliberately retired in #25 when its backlog moved to issues, but that change only touched `CHANGELOG.md` — the README was missed, so the link has been broken since 1.0.0 shipped.
2. **Stale content.** The sentence listed four items as "outstanding hardening", but *keystore format versioning* and *zero-on-dispose for caller-supplied entropy* both shipped in 1.0.0. The README was advertising finished work as a backlog.

## Checklist

- [x] Build is clean — no new warnings (`TreatWarningsAsErrors` is on)
- [x] Tests pass on **every** shipped target framework
- [x] Public API changes carry XML docs — n/a, no API change
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Dependency floors unchanged, or the consumer impact is described below

## Consumer impact

None. Docs only — no public signature, on-disk format, dependency floor, or target framework change. Stored credentials are unaffected.

## Note

One further dangling reference to the retired TODO remains, deliberately left out of scope here: `CredentialEncryptionFactory.cs:14` says "see the solution TODO for the planned backends" in an XML doc on a public API, so it ships in the docs and `.snupkg`. It is stale three ways — the TODO is gone, both OS-native backends already shipped, and the architectural premise is wrong (Keychain/libsecret replace `ICredentialManager` and bypass `ICredentialEncryption` entirely, so this factory will never return them). Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
