### PR TITLE
docs: drop the last retired-TODO reference and the closed #18 item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   issue tracker and names only the two genuinely open items: ACL-scoped Keychain access (#18)
   and libsecret KWallet validation (#19).
 
+- **`CredentialEncryptionFactory.Create` carried the same retired-TODO reference in its XML
+  doc**, which ships in the generated docs and `.snupkg`. It was stale three ways: the TODO
+  is gone, both OS-native backends have since shipped, and the premise was wrong — the
+  Keychain and libsecret backends replace `ICredentialManager` and never pass through
+  `ICredentialEncryption`, so this factory could never have returned them. The doc now says
+  what actually selects those backends. XML docs only; no API surface change.
+
+- **Dropped ACL-scoped Keychain access from the README's outstanding-hardening list.** Issue
+  #18 was closed as won't-do: binding credential items to the creating binary was
+  investigated and rejected, so listing it as planned work was misleading.
+
 ## [1.0.1] — 2026-08-22
 
 Maintenance release. No API or behavior change for consumers: a behavior-identical

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Everything else is transitive.
 
 ## Contributing
 
-Issues and PRs welcome. Outstanding hardening is tracked in [GitHub issues](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues) — currently ACL-scoped Keychain access ([#18](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues/18)) and KWallet validation for the libsecret backend ([#19](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues/19)).
+Issues and PRs welcome. Outstanding hardening is tracked in [GitHub issues](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues) — currently KWallet validation for the libsecret backend ([#19](https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/issues/19)).
 
 When contributing code, please keep the zero-warning, fully-documented public surface. `TreatWarningsAsErrors` is on for a reason.
 

--- a/src/NextIteration.SpectreConsole.Auth/Encryption/CredentialEncryptionFactory.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Encryption/CredentialEncryptionFactory.cs
@@ -9,9 +9,12 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
     {
         /// <summary>
         /// Creates the default encryption implementation for the current platform.
-        /// Today this is always <see cref="LocalFileCredentialEncryption"/>. In
-        /// the future this may switch to an OS-native keychain on macOS/Linux
-        /// automatically — see the solution TODO for the planned backends.
+        /// Today this is always <see cref="LocalFileCredentialEncryption"/>. The
+        /// OS-native stores (macOS Keychain, Linux libsecret) are chosen at the
+        /// credential-manager level via <see cref="CredentialStoreOptions.UseKeychain"/>
+        /// / <see cref="CredentialStoreOptions.UseKeyring"/> and bypass this factory
+        /// entirely — they replace <see cref="Persistence.ICredentialManager"/> rather
+        /// than plugging in as an <see cref="ICredentialEncryption"/>.
         /// </summary>
         /// <param name="credentialsDirectory">Credentials directory where the keystore will live.</param>
         /// <param name="additionalEntropy">


### PR DESCRIPTION
## What changed

- `CredentialEncryptionFactory.Create`'s XML doc no longer points at the retired `TODO.md`, and now describes what actually selects the OS-native backends.
- The README's outstanding-hardening list drops ACL-scoped Keychain access, since #18 is closed as won't-do.

## Why

Follow-up to #36, which fixed the README's dangling `TODO.md` link but left one more behind.

1. **The factory doc shipped the stale reference to consumers.** `CredentialEncryptionFactory.cs` said "see the solution TODO for the planned backends" in an XML doc on a public API, so it went out in the generated docs and the `.snupkg`. Stale three ways: the TODO was retired in #25, both OS-native backends have since shipped, and the architectural premise was wrong — Keychain and libsecret replace `ICredentialManager` and never pass through `ICredentialEncryption`, so this factory could never have returned them.

2. **#36 named #18 as outstanding hardening, and #18 is now closed won't-do.** Binding credential items to the creating binary was investigated and rejected. Leaving the README as-is would advertise work that is not planned — reintroducing exactly the staleness #36 fixed.

## Checklist

- [x] Build is clean — no new warnings (`TreatWarningsAsErrors` is on)
- [x] Tests pass on **every** shipped target framework
- [x] Public API changes carry XML docs — n/a, no API change; the XML doc content itself is what changed
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Dependency floors unchanged, or the consumer impact is described below

## Consumer impact

None to behaviour. The only consumer-visible difference is corrected prose in IntelliSense / the generated documentation. No public signature, on-disk format, dependency floor, or target framework change; stored credentials are unaffected.

Every new `cref` was verified to resolve against a real symbol in the generated `NextIteration.SpectreConsole.Auth.xml`, not merely to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
