### PR TITLE
fix: tolerate undecryptable credentials in list/export/import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`accounts import` aborted when any existing local credential could not be decrypted**
+  (#38). The reported failure surfaced as *"Credential data failed integrity check … the
+  keystore was copied from another machine or user"* on a correct passphrase, because the
+  message came from the local keystore, not the archive. `ImportAsync` called
+  `ExportCredentialsAsync` to build its conflict index, and the file backend's `DecryptAsync`
+  there sat outside the `try`/`catch` — so one unreadable credential file in the destination
+  vetoed the whole import. That fired in exactly the situation export/import exists to fix: a
+  credentials directory carried to a new machine, then repaired via export/import.
+
+  The root cause was deeper than a missing `catch`. Conflict detection only ever needed the
+  provider, account name and environment — all stored in plaintext — never the encrypted
+  payload, and the resolver `accounts import` builds ignores the existing side entirely. The
+  index is now built from metadata via `GetProviderNamesAsync` + `ListCredentialsAsync`, so an
+  import no longer decrypts the store at all and no longer materialises every secret in memory
+  for an operation that never reads one. All the affected types are `internal`; no public API
+  change and no `ICredentialManager` member added.
+
+- **`accounts list` died entirely when one credential could not be decrypted** (#38). The same
+  unguarded decrypt in `ListCredentialsAsync` (inside a `try` catching only `JsonException`)
+  took out the whole listing for a provider whenever an `ICredentialSummaryProvider` was
+  registered for it — which also blocked the repair path, since `accounts delete <id>` needs
+  the id to be visible. A broken row now renders without its provider columns and is marked
+  `(unreadable)`, with a hint pointing at `--on-conflict overwrite` and `accounts delete`.
+
+  `CredentialSummary` gains `IsDecryptable` to distinguish "payload unreadable" from "no
+  summary provider registered". Additive: not `required`, defaults to `true`, so external
+  `ICredentialManager` implementations are unaffected.
+
+- **`accounts export` now reports credentials it had to leave out.** An unreadable credential
+  is skipped rather than aborting the export, but it is *dropped* rather than written with an
+  empty payload — `CredentialData` flows straight into the archive, so a blank secret would
+  become silent corruption at the next import. A short archive is otherwise invisible until a
+  restore comes up empty, so the count is now warned about, and an export where *everything*
+  failed to decrypt reports that and exits non-zero instead of claiming "nothing to export".
+
+  `GetSelectedCredentialAsync` and `GetCredentialByIdAsync` deliberately still throw. Those
+  are targeted fetches: returning `null` would masquerade as "no credential selected" and hand
+  a consumer a worse diagnosis than the real one. Tests pin that split so a future over-broad
+  catch cannot erode it.
+
+  File backend only — the Keychain and libsecret backends read secrets straight from the OS
+  store and never call `ICredentialEncryption`.
+
 - **The README's Contributing section pointed at the retired `TODO.md`.** That file was
   removed in #25 when its backlog moved to GitHub issues, but the change never updated the
   README, so the link has been dead since 1.0.0. The same sentence also listed keystore

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ExportCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ExportCredentialsCommand.cs
@@ -42,8 +42,13 @@ namespace NextIteration.SpectreConsole.Auth.Commands
 
                 if (result.Count == 0)
                 {
-                    AnsiConsole.MarkupLine("[yellow]No credentials to export.[/]");
-                    return 0;
+                    // All-unreadable is a very different situation from an empty
+                    // store, and reporting it as "nothing to export" would hide a
+                    // broken store behind a success message.
+                    AnsiConsole.MarkupLine(result.Skipped > 0
+                        ? $"[red]Nothing exported: all {result.Skipped} stored credential(s) failed to decrypt with this machine's keystore.[/]"
+                        : "[yellow]No credentials to export.[/]");
+                    return result.Skipped > 0 ? 1 : 0;
                 }
 
                 // 0600 on Unix so the archive isn't world-readable while it sits
@@ -54,6 +59,15 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                     OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);
 
                 AnsiConsole.MarkupLine($"[green]Exported {result.Count} credential(s) to {Markup.Escape(settings.File)}.[/]");
+
+                if (result.Skipped > 0)
+                {
+                    // Loud, because the archive is incomplete and the omission is
+                    // otherwise invisible until a restore comes up short.
+                    AnsiConsole.MarkupLine(
+                        $"[yellow]Warning: {result.Skipped} credential(s) were left out because they could not be decrypted with this machine's keystore. The archive is incomplete — run 'accounts list' to see which.[/]");
+                }
+
                 AnsiConsole.MarkupLine("[grey]The archive holds every secret, protected only by the passphrase. Keep it and the passphrase safe.[/]");
                 return 0;
             }

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ImportCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ImportCredentialsCommand.cs
@@ -109,7 +109,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
             return false;
         }
 
-        private static Func<CredentialExport, CredentialExport, ConflictResolution> BuildConflictResolver(
+        private static Func<CredentialExport, CredentialSummary, ConflictResolution> BuildConflictResolver(
             string? onConflict, ConflictResolution forcedResolution)
         {
             // An explicit --on-conflict pins the decision for every collision.

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ListCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ListCredentialsCommand.cs
@@ -107,10 +107,20 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                 // Cells render via Spectre markup, so user/provider-controlled
                 // values must be escaped — an account name like "[red]X[/]"
                 // would otherwise be parsed as styling rather than text.
+                var name = Markup.Escape(credential.AccountName);
+                if (!credential.IsDecryptable)
+                {
+                    // The row is rendered so its id stays visible (that is what
+                    // `accounts delete` needs), but the provider columns are blank
+                    // because the payload could not be opened. Mark it so that is
+                    // distinguishable from a provider with no summary fields.
+                    name += " [red](unreadable)[/]";
+                }
+
                 var row = new List<string>
                 {
                     CommandFormatting.ShortId(credential.AccountId),
-                    Markup.Escape(credential.AccountName),
+                    name,
                     Markup.Escape(credential.Environment),
                 };
 
@@ -130,6 +140,12 @@ namespace NextIteration.SpectreConsole.Auth.Commands
             _ = table.Expand();
 
             AnsiConsole.Write(table);
+
+            if (credentials.Exists(c => !c.IsDecryptable))
+            {
+                AnsiConsole.MarkupLine(
+                    "[grey]Rows marked (unreadable) could not be decrypted with this machine's keystore. Re-import them with 'accounts import --on-conflict overwrite', or remove them with 'accounts delete <id>'.[/]");
+            }
         }
     }
 }

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
@@ -84,10 +84,25 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                                        selectedId.Equals(credential.AccountId, StringComparison.OrdinalIgnoreCase);
 
                         IReadOnlyList<KeyValuePair<string, string>> displayFields = [];
+                        var isDecryptable = true;
                         if (summaryProvider is not null)
                         {
-                            var decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
-                            displayFields = summaryProvider.GetDisplayFields(decrypted);
+                            try
+                            {
+                                var decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
+                                displayFields = summaryProvider.GetDisplayFields(decrypted);
+                            }
+                            catch (InvalidOperationException)
+                            {
+                                // The payload cannot be opened with this machine's
+                                // keystore — typically a credentials directory copied
+                                // from another machine or user, or a keystore that was
+                                // replaced while its credential files survived. Render
+                                // the row without provider columns rather than taking
+                                // down the whole listing: the user needs to see the id
+                                // to remove it with `accounts delete`.
+                                isDecryptable = false;
+                            }
                         }
 
                         credentials.Add(new CredentialSummary
@@ -99,6 +114,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                             CreatedAt = credential.CreatedAt,
                             IsSelected = isSelected,
                             DisplayFields = displayFields,
+                            IsDecryptable = isDecryptable,
                         });
                     }
                 }
@@ -349,7 +365,23 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                 var isSelected = selections.TryGetValue(credential.ProviderName, out var selectedId) &&
                     selectedId.Equals(credential.AccountId, StringComparison.OrdinalIgnoreCase);
 
-                var decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
+                string decrypted;
+                try
+                {
+                    decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
+                }
+                catch (InvalidOperationException)
+                {
+                    // Unreadable ciphertext: skip rather than abort. One credential
+                    // the local keystore cannot open must not veto an export of the
+                    // rest, nor an import that only needs this metadata.
+                    //
+                    // Dropped rather than emitted with an empty payload on purpose —
+                    // CredentialData flows straight into the archive, so an empty
+                    // secret would become silent corruption at the next import.
+                    // The caller reports the count instead.
+                    continue;
+                }
 
                 exports.Add(new CredentialExport
                 {

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
@@ -139,9 +139,27 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// <summary>
         /// Provider-specific label/value pairs projected from the decrypted
         /// credential by the registered <see cref="ICredentialSummaryProvider"/>.
-        /// Empty when no summary provider is registered for this provider.
+        /// Empty when no summary provider is registered for this provider, and
+        /// also when the payload could not be decrypted — see
+        /// <see cref="IsDecryptable"/> to tell those apart.
         /// </summary>
         public IReadOnlyList<KeyValuePair<string, string>> DisplayFields { get; init; } = [];
+
+        /// <summary>
+        /// Display hint: <see langword="false"/> when the stored payload was read
+        /// and failed to decrypt, so <see cref="DisplayFields"/> is empty for that
+        /// reason rather than because no summary provider is registered.
+        /// </summary>
+        /// <remarks>
+        /// This is not a guarantee that the payload <em>is</em> readable. The
+        /// payload is only read when an <see cref="ICredentialSummaryProvider"/> is
+        /// registered for the provider; with none registered nothing is decrypted
+        /// and this stays <see langword="true"/> even for an unreadable credential.
+        /// Callers that must know for certain should attempt
+        /// <see cref="ICredentialManager.GetCredentialByIdAsync"/>, which throws on
+        /// an unreadable payload rather than hiding it.
+        /// </remarks>
+        public bool IsDecryptable { get; init; } = true;
     }
 
     /// <summary>

--- a/src/NextIteration.SpectreConsole.Auth/Portability/CredentialPortabilityService.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Portability/CredentialPortabilityService.cs
@@ -18,7 +18,12 @@ namespace NextIteration.SpectreConsole.Auth.Portability
     /// <summary>Outcome of an <see cref="CredentialPortabilityService.ExportAsync"/> call.</summary>
     /// <param name="Bundle">The passphrase-encrypted archive text.</param>
     /// <param name="Count">Number of credentials written into the archive.</param>
-    internal sealed record ExportResult(string Bundle, int Count);
+    /// <param name="Skipped">
+    /// Stored credentials left out because their payload could not be decrypted.
+    /// Surfaced so the command can warn: a silently short archive is a data-loss
+    /// trap, since the missing secrets look like they were never stored.
+    /// </param>
+    internal sealed record ExportResult(string Bundle, int Count, int Skipped);
 
     /// <summary>Outcome of an <see cref="CredentialPortabilityService.ImportAsync"/> call.</summary>
     /// <param name="Added">Credentials that did not exist and were created.</param>
@@ -51,7 +56,13 @@ namespace NextIteration.SpectreConsole.Auth.Portability
         {
             var credentials = await _manager.ExportCredentialsAsync().ConfigureAwait(false);
             var bundle = CredentialArchive.Serialize(credentials, passphrase);
-            return new ExportResult(bundle, credentials.Count);
+
+            // The backend drops credentials it cannot decrypt, so the archive may
+            // hold fewer than the store does. Derive the difference from the
+            // metadata listing rather than widening the public
+            // ICredentialManager.ExportCredentialsAsync signature to report it.
+            var stored = await CountStoredCredentialsAsync().ConfigureAwait(false);
+            return new ExportResult(bundle, credentials.Count, Math.Max(0, stored - credentials.Count));
         }
 
         /// <summary>
@@ -64,26 +75,18 @@ namespace NextIteration.SpectreConsole.Auth.Portability
         /// <param name="passphrase">The passphrase the archive was written with.</param>
         /// <param name="resolveConflict">
         /// Called once per collision with (incoming, existing) and returns how to
-        /// resolve it. Invoked only when there is an actual conflict.
+        /// resolve it. Invoked only when there is an actual conflict. The existing
+        /// side is metadata only — see <see cref="BuildConflictIndexAsync"/>.
         /// </param>
         internal async Task<ImportResult> ImportAsync(
             string bundle,
             string passphrase,
-            Func<CredentialExport, CredentialExport, ConflictResolution> resolveConflict)
+            Func<CredentialExport, CredentialSummary, ConflictResolution> resolveConflict)
         {
             ArgumentNullException.ThrowIfNull(resolveConflict);
 
             var incoming = CredentialArchive.Deserialize(bundle, passphrase);
-            var existing = await _manager.ExportCredentialsAsync().ConfigureAwait(false);
-
-            // Index existing credentials by their semantic identity. Duplicates
-            // on the same key are unusual but possible; keep the first as the
-            // conflict target.
-            var existingByKey = new Dictionary<string, CredentialExport>(StringComparer.Ordinal);
-            foreach (var e in existing)
-            {
-                _ = existingByKey.TryAdd(ConflictKey(e), e);
-            }
+            var existingByKey = await BuildConflictIndexAsync().ConfigureAwait(false);
 
             var added = 0;
             var overwritten = 0;
@@ -116,16 +119,66 @@ namespace NextIteration.SpectreConsole.Auth.Portability
             return new ImportResult(added, overwritten, skipped);
         }
 
+        /// <summary>
+        /// Indexes the credentials already in the store by their semantic identity,
+        /// reading <b>metadata only</b>.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not <see cref="ICredentialManager.ExportCredentialsAsync"/>.
+        /// Conflict detection needs only the provider, account name and environment
+        /// — all stored in plaintext — never the encrypted payload. Decrypting the
+        /// whole store to build this index was both wasteful (every secret
+        /// materialised in memory for an operation that never reads one) and fatal:
+        /// a single credential the local keystore cannot open aborted the entire
+        /// import, which is exactly the store an import is meant to repair.
+        /// </remarks>
+        private async Task<Dictionary<string, CredentialSummary>> BuildConflictIndexAsync()
+        {
+            var index = new Dictionary<string, CredentialSummary>(StringComparer.Ordinal);
+
+            foreach (var provider in await _manager.GetProviderNamesAsync().ConfigureAwait(false))
+            {
+                foreach (var summary in await _manager.ListCredentialsAsync(provider).ConfigureAwait(false))
+                {
+                    // Duplicates on the same key are unusual but possible; keep the
+                    // first as the conflict target.
+                    _ = index.TryAdd(
+                        ConflictKey(summary.ProviderName, summary.AccountName, summary.Environment),
+                        summary);
+                }
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Counts what the store holds, from metadata only, so an export can report
+        /// how many credentials it had to leave out.
+        /// </summary>
+        private async Task<int> CountStoredCredentialsAsync()
+        {
+            var count = 0;
+            foreach (var provider in await _manager.GetProviderNamesAsync().ConfigureAwait(false))
+            {
+                count += (await _manager.ListCredentialsAsync(provider).ConfigureAwait(false)).Count();
+            }
+
+            return count;
+        }
+
+        private static string ConflictKey(CredentialExport c) =>
+            ConflictKey(c.ProviderName, c.AccountName, c.Environment);
+
         // Semantic identity used to detect "the same" credential across machines,
         // where account ids differ. Case-insensitive on all three parts, and
         // length-prefixed so no combination of separators inside a value can make
         // two different triples collide onto one key.
-        private static string ConflictKey(CredentialExport c)
+        private static string ConflictKey(string providerName, string accountName, string environment)
         {
-            var provider = c.ProviderName.ToLowerInvariant();
-            var name = c.AccountName.ToLowerInvariant();
-            var environment = c.Environment.ToLowerInvariant();
-            return $"{provider.Length}:{provider}|{name.Length}:{name}|{environment.Length}:{environment}";
+            var provider = providerName.ToLowerInvariant();
+            var name = accountName.ToLowerInvariant();
+            var env = environment.ToLowerInvariant();
+            return $"{provider.Length}:{provider}|{name.Length}:{name}|{env.Length}:{env}";
         }
     }
 }

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/CredentialCorruption.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/CredentialCorruption.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace NextIteration.SpectreConsole.Auth.Tests.Infrastructure
+{
+    /// <summary>
+    /// Makes a stored credential undecryptable, reproducing the real-world state
+    /// behind issue #38: a credentials directory carried to another machine or
+    /// user, or a keystore replaced while its credential files survived. In both
+    /// cases the file parses fine as JSON and its metadata is intact — only the
+    /// AES-GCM payload fails its authentication tag.
+    /// </summary>
+    /// <remarks>
+    /// Corrupting the ciphertext rather than deleting the keystore is deliberate:
+    /// it breaks exactly one credential and leaves its neighbours readable, which
+    /// is what the tolerance behaviour has to be proven against. Deleting the
+    /// keystore would break every credential at once and prove much less.
+    /// </remarks>
+    internal static class CredentialCorruption
+    {
+        /// <summary>
+        /// Flips a byte inside the encrypted payload of the credential file for
+        /// <paramref name="providerName"/>/<paramref name="accountId"/>, leaving
+        /// the JSON structure and all plaintext metadata untouched.
+        /// </summary>
+        internal static void CorruptPayload(string credentialsDirectory, string providerName, string accountId)
+        {
+            var path = Path.Join(credentialsDirectory, $"{providerName.ToLowerInvariant()}_{accountId}.json");
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"No stored credential at '{path}'.", path);
+            }
+
+            var node = JsonNode.Parse(File.ReadAllText(path))
+                ?? throw new InvalidOperationException($"'{path}' did not parse as a JSON object.");
+
+            // The manager writes camelCase, matching its JsonSerializerOptions.
+            var encoded = node["credentialData"]?.GetValue<string>()
+                ?? throw new InvalidOperationException($"'{path}' has no credentialData field.");
+
+            var bytes = Convert.FromBase64String(encoded);
+
+            // Land the flip in the ciphertext, past the [nonce(12)][tag(16)] header,
+            // so the failure is an authentication-tag mismatch on real ciphertext
+            // rather than a malformed-header rejection.
+            const int headerLength = 12 + 16;
+            if (bytes.Length <= headerLength)
+            {
+                throw new InvalidOperationException(
+                    $"Payload in '{path}' is {bytes.Length} bytes — too short to corrupt past its header.");
+            }
+
+            bytes[headerLength] ^= 0xFF;
+            node["credentialData"] = Convert.ToBase64String(bytes);
+
+            File.WriteAllText(path, node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        }
+    }
+}

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -590,6 +590,122 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             _ = await Assert.ThrowsAsync<ArgumentException>(() => manager.RestoreCredentialAsync(bad));
         }
 
+        // ---- Undecryptable credentials (#38) --------------------------------
+        //
+        // A credentials directory copied between machines/users, or a keystore
+        // replaced while its credential files survived, leaves files that parse
+        // as JSON with intact plaintext metadata but an unopenable payload. The
+        // enumeration paths must tolerate that; the targeted fetch paths must not.
+
+        [Fact]
+        public async Task ListCredentialsAsync_UndecryptableCredential_StillListsEveryRow()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path, [new FakeAdobeSummaryProvider()]);
+
+            var goodId = await manager.AddCredentialAsync("Adobe", "good", "Production", "{\"apiKey\":\"KEEP\"}");
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{\"apiKey\":\"LOST\"}");
+            CredentialCorruption.CorruptPayload(temp.Path, "Adobe", badId);
+
+            var listed = (await manager.ListCredentialsAsync("Adobe")).ToList();
+
+            Assert.Equal(2, listed.Count);
+
+            var good = listed.Single(c => c.AccountId == goodId);
+            Assert.True(good.IsDecryptable);
+            Assert.NotEmpty(good.DisplayFields);
+
+            // The broken row survives: its id has to stay visible, because that is
+            // what `accounts delete <id>` needs to clear it.
+            var bad = listed.Single(c => c.AccountId == badId);
+            Assert.False(bad.IsDecryptable);
+            Assert.Empty(bad.DisplayFields);
+            Assert.Equal("bad", bad.AccountName);
+        }
+
+        [Fact]
+        public async Task ListCredentialsAsync_NoSummaryProvider_DoesNotReadPayload()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path); // no summary provider registered
+
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{}");
+            CredentialCorruption.CorruptPayload(temp.Path, "Adobe", badId);
+
+            var listed = (await manager.ListCredentialsAsync("Adobe")).ToList();
+
+            // Nothing is decrypted without a summary provider, so the flag stays
+            // true even though the payload is in fact unreadable. Pins the
+            // documented meaning of IsDecryptable as a display hint, not a promise.
+            Assert.True(Assert.Single(listed).IsDecryptable);
+        }
+
+        [Fact]
+        public async Task ExportCredentialsAsync_UndecryptableCredential_SkipsItAndKeepsTheRest()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+
+            var goodId = await manager.AddCredentialAsync("Adobe", "good", "Production", "{\"k\":\"KEEP\"}");
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{\"k\":\"LOST\"}");
+            CredentialCorruption.CorruptPayload(temp.Path, "Adobe", badId);
+
+            var exported = await manager.ExportCredentialsAsync();
+
+            // Dropped, never emitted with an empty payload: CredentialData flows
+            // straight into the archive, so a blank secret would be silent
+            // corruption at the next import.
+            var only = Assert.Single(exported);
+            Assert.Equal(goodId, only.AccountId);
+            Assert.Equal("{\"k\":\"KEEP\"}", only.CredentialData);
+        }
+
+        [Fact]
+        public async Task DeleteCredentialAsync_UndecryptableCredential_RemovesIt()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{}");
+            CredentialCorruption.CorruptPayload(temp.Path, "Adobe", badId);
+
+            // The repair path: delete works on metadata alone and never decrypts.
+            Assert.True(await manager.DeleteCredentialAsync(badId));
+            Assert.False(File.Exists(Path.Join(temp.Path, $"adobe_{badId}.json")));
+        }
+
+        [Fact]
+        public async Task GetSelectedCredentialAsync_UndecryptableCredential_StillThrows()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{}");
+            Assert.True(await manager.SelectCredentialAsync(badId));
+            CredentialCorruption.CorruptPayload(temp.Path, "Adobe", badId);
+
+            // Deliberately NOT tolerant. This is a targeted fetch: the caller asked
+            // for one specific credential and it cannot be supplied. Returning null
+            // would masquerade as "no credential selected" and hand the consumer a
+            // worse diagnosis than the real one. Guards the enumeration/fetch split
+            // against a future over-broad catch.
+            _ = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => manager.GetSelectedCredentialAsync("Adobe"));
+        }
+
+        [Fact]
+        public async Task GetCredentialByIdAsync_UndecryptableCredential_StillThrows()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{}");
+            CredentialCorruption.CorruptPayload(temp.Path, "Adobe", badId);
+
+            _ = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => manager.GetCredentialByIdAsync("Adobe", badId));
+        }
+
         /// <summary>
         /// Minimal summary provider used only to verify that
         /// <see cref="FileCredentialManager.ListCredentialsAsync"/> routes

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Portability/CredentialPortabilityServiceTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Portability/CredentialPortabilityServiceTests.cs
@@ -92,7 +92,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Portability
             var targetManager = NewManager(target.Path);
 
             // Pre-existing credential the incoming one will collide with.
-            _ = await targetManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"OLD\"}");
+            var existingId = await targetManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"OLD\"}");
 
             // Craft an incoming archive with the same identity (provider/name/env)
             // but a different account id and payload.
@@ -114,7 +114,16 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Portability
                 {
                     conflictSeen++;
                     Assert.Equal("prod", inc.AccountName);
-                    Assert.Equal("{\"k\":\"OLD\"}", existing.CredentialData);
+
+                    // The resolver sees the matched existing credential as metadata
+                    // only. Conflict resolution never needs its payload, and
+                    // decrypting the store to supply one broke import outright
+                    // whenever a single credential was unreadable (#38).
+                    Assert.Equal(existingId, existing.AccountId);
+                    Assert.Equal("prod", existing.AccountName);
+                    Assert.Equal("Adobe", existing.ProviderName);
+                    Assert.Equal("Production", existing.Environment);
+                    Assert.NotEqual(incoming.AccountId, existing.AccountId);
                     return ConflictResolution.Overwrite;
                 });
 
@@ -153,6 +162,130 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Portability
             Assert.Equal(1, result.Added);
             Assert.Equal(0, result.Overwritten);
             Assert.Equal(2, (await targetManager.ExportCredentialsAsync()).Count);
+        }
+
+        // ---- Undecryptable credentials in the destination store (#38) --------
+
+        [Fact]
+        public async Task Import_UndecryptableCredentialInStore_Succeeds()
+        {
+            using var target = new TempDir();
+            var targetManager = NewManager(target.Path);
+
+            // An unrelated credential the local keystore cannot open. Before the
+            // fix this aborted the whole import with an integrity-check error,
+            // because conflict detection decrypted the entire store.
+            var badId = await targetManager.AddCredentialAsync("Airtable", "stale", "Production", "{\"k\":\"LOST\"}");
+            CredentialCorruption.CorruptPayload(target.Path, "Airtable", badId);
+
+            var incoming = new CredentialExport
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                AccountName = "prod",
+                ProviderName = "Adobe",
+                Environment = "Production",
+                CredentialData = "{\"k\":\"NEW\"}",
+                CreatedAt = new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc),
+                IsSelected = false,
+            };
+            var bundle = CredentialArchive.Serialize([incoming], Passphrase);
+
+            var result = await new CredentialPortabilityService(targetManager)
+                .ImportAsync(bundle, Passphrase, (_, _) => ConflictResolution.Skip);
+
+            Assert.Equal(1, result.Added);
+            Assert.Equal(0, result.Skipped);
+            Assert.Equal("{\"k\":\"NEW\"}", await targetManager.GetCredentialByIdAsync("Adobe", incoming.AccountId));
+        }
+
+        [Fact]
+        public async Task Import_OverwriteOntoUndecryptableCredential_ReplacesIt()
+        {
+            using var target = new TempDir();
+            var targetManager = NewManager(target.Path);
+
+            var badId = await targetManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"LOST\"}");
+            Assert.True(await targetManager.SelectCredentialAsync(badId));
+            CredentialCorruption.CorruptPayload(target.Path, "Adobe", badId);
+
+            var incoming = new CredentialExport
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                AccountName = "prod",
+                ProviderName = "Adobe",
+                Environment = "Production",
+                CredentialData = "{\"k\":\"NEW\"}",
+                CreatedAt = new DateTime(2024, 5, 6, 7, 8, 9, DateTimeKind.Utc),
+                IsSelected = true,
+            };
+            var bundle = CredentialArchive.Serialize([incoming], Passphrase);
+
+            // The unreadable entry is matched on plaintext metadata, so it presents
+            // as a conflict rather than silently adding a duplicate alongside it.
+            // Overwrite is the invocation that actually repairs a broken store.
+            var result = await new CredentialPortabilityService(targetManager)
+                .ImportAsync(bundle, Passphrase, (_, _) => ConflictResolution.Overwrite);
+
+            Assert.Equal(1, result.Overwritten);
+            Assert.Equal(0, result.Added);
+
+            var stored = await SingleExportAsync(targetManager);
+            Assert.Equal(incoming.AccountId, stored.AccountId);
+            Assert.Equal("{\"k\":\"NEW\"}", stored.CredentialData);
+            Assert.True(stored.IsSelected);
+            Assert.False(File.Exists(Path.Join(target.Path, $"adobe_{badId}.json")));
+        }
+
+        [Fact]
+        public async Task Import_SkipOntoUndecryptableCredential_LeavesStoreBroken()
+        {
+            using var target = new TempDir();
+            var targetManager = NewManager(target.Path);
+
+            var badId = await targetManager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"LOST\"}");
+            CredentialCorruption.CorruptPayload(target.Path, "Adobe", badId);
+
+            var incoming = new CredentialExport
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                AccountName = "prod",
+                ProviderName = "Adobe",
+                Environment = "Production",
+                CredentialData = "{\"k\":\"NEW\"}",
+                CreatedAt = DateTime.UtcNow,
+                IsSelected = false,
+            };
+            var bundle = CredentialArchive.Serialize([incoming], Passphrase);
+
+            var result = await new CredentialPortabilityService(targetManager)
+                .ImportAsync(bundle, Passphrase, (_, _) => ConflictResolution.Skip);
+
+            // Documents the trap: skip is the non-interactive default, and it repairs
+            // nothing. `--on-conflict overwrite` is required to fix a broken store.
+            Assert.Equal(1, result.Skipped);
+            Assert.Equal(0, result.Added);
+            Assert.True(File.Exists(Path.Join(target.Path, $"adobe_{badId}.json")));
+        }
+
+        [Fact]
+        public async Task Export_UndecryptableCredential_IsReportedAsSkipped()
+        {
+            using var source = new TempDir();
+            var manager = NewManager(source.Path);
+
+            _ = await manager.AddCredentialAsync("Adobe", "good", "Production", "{\"k\":\"KEEP\"}");
+            var badId = await manager.AddCredentialAsync("Adobe", "bad", "Production", "{\"k\":\"LOST\"}");
+            CredentialCorruption.CorruptPayload(source.Path, "Adobe", badId);
+
+            var export = await new CredentialPortabilityService(manager).ExportAsync(Passphrase);
+
+            // A silently short archive is a data-loss trap: the missing secrets look
+            // like they were never stored. The count is surfaced so the command warns.
+            Assert.Equal(1, export.Count);
+            Assert.Equal(1, export.Skipped);
+
+            var restored = CredentialArchive.Deserialize(export.Bundle, Passphrase);
+            Assert.Equal("good", Assert.Single(restored).AccountName);
         }
     }
 }


### PR DESCRIPTION
Fixes #38.

## What changed

`accounts import` no longer aborts when an existing local credential cannot be decrypted, `accounts list` no longer dies on one, and `accounts export` skips them with a warning instead of failing outright.

## Why

The reported failure showed an integrity-check error about the *keystore* on a **correct** passphrase, because the message came from `LocalFileCredentialEncryption`, not the archive. `ImportAsync` built its conflict index via `ExportCredentialsAsync`, whose `DecryptAsync` sat outside the `try`/`catch` — so one unreadable credential file in the destination vetoed the entire import. That fires in exactly the situation export/import exists to fix: a credentials directory carried to a new machine, then repaired properly via export/import.

**The root cause was not a missing `catch`.** Conflict detection only ever needed provider, account name and environment — all stored in plaintext — never the encrypted payload, and the resolver `ImportCredentialsCommand` builds ignores the existing side entirely. So the index is now built from metadata (`GetProviderNamesAsync` + `ListCredentialsAsync`): an import no longer decrypts the store at all, and no longer materialises every secret in memory for an operation that never reads one.

## Design notes

- **`GetSelectedCredentialAsync` / `GetCredentialByIdAsync` deliberately still throw.** Those are targeted fetches — returning `null` would masquerade as "no credential selected" and hand a consumer a worse diagnosis than the real one. Guard the *enumeration* paths, not the *fetch* paths; two tests pin the split so a future over-broad catch cannot erode it.
- **Unreadable credentials are dropped from an archive, never written with an empty payload.** `CredentialData` flows straight into the archive, so a blank secret would become silent corruption at the next import. A short archive is invisible until a restore comes up empty, hence the warning and the count.
- **`CredentialSummary.IsDecryptable` is additive** — not `required`, defaults to `true` — so external `ICredentialManager` implementations are unaffected. It is documented as a display hint, not a guarantee: nothing is decrypted when no summary provider is registered, so it stays `true` for an unreadable credential in that case. A test pins that.
- **File backend only.** The Keychain and libsecret backends read secrets straight from the OS store and never call `ICredentialEncryption`.

## What happens to the undecryptable files

Nothing deletes them automatically. They stay visible in `accounts list` marked `(unreadable)`, are treated as conflicts on import so `--on-conflict overwrite` replaces them, are dropped from exports with a warning, and remain removable with the existing `accounts delete <id>` (which never decrypts). Plain `skip` — the non-interactive default — repairs nothing, which a test documents explicitly.

## Verification

Build clean (0 warnings), **354 tests pass** on both TFMs, up from 334.

The 10 new tests were proven non-vacuous rather than assumed: removing the export guard makes them fail with the exact message from the original report —

```
System.InvalidOperationException : Credential data failed integrity check. The file has been
tampered with, or was encrypted with a different key (for example, the keystore was copied
from another machine or user).
```

The command layer renders through static `AnsiConsole` and so is not unit-testable; the new marker and warning strings were separately rendered through Spectre to confirm the markup parses, including an account name containing `[` / `]` metacharacters.

## Follow-up not in scope

`LibsecretCredentialManager.ExportCredentialsAsync` uses `item.Secret ?? string.Empty`, exporting a missing secret as an *empty credential* rather than skipping it — the same silent-corruption shape by a different route. Noted in #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
