### PR TITLE
fix: stop concurrent first runs destroying each other's credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two concurrent first runs could silently destroy one set of credentials** (#44). Keystore
+  creation was an unlocked check-then-write: both invocations found no `.keystore`, both spent
+  ~200ms deriving a KEK, and the second write replaced the first via an unconditional atomic
+  overwrite. Anything the first process had already encrypted was then permanently
+  undecryptable — and it surfaced as the same "failed integrity check" message as a keystore
+  copied between machines, so it was easy to misdiagnose. `AtomicFile` gains
+  `TryWriteNewAsync`, a temp-then-**non-overwriting**-rename, so the losing racer discards its
+  key and adopts the winner's instead of persisting data under a key no longer on disk.
+  Crash-safety is unchanged; only the final rename's overwrite behaviour differs.
+
 - **The Keychain and libsecret backends exported an empty credential when a secret failed to
   load** (#42). Both fabricated a blank payload rather than skipping the item —
   `item.Secret ?? string.Empty` on libsecret, the `item.Data is not null ? … : string.Empty`

--- a/src/NextIteration.SpectreConsole.Auth/Encryption/LocalFileCredentialEncryption.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Encryption/LocalFileCredentialEncryption.cs
@@ -224,6 +224,10 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
         {
             if (!File.Exists(_keyFile))
             {
+                // Create-if-absent, and deliberately ignore whether we won: the read
+                // below is what decides which key is used, so a racer that lost simply
+                // adopts the winner's key instead of persisting data under a key that
+                // is no longer on disk.
                 await CreateKeyFileAsync().ConfigureAwait(false);
             }
 
@@ -282,10 +286,17 @@ namespace NextIteration.SpectreConsole.Auth.Encryption
                 CredentialsDirectory.Ensure(directory);
             }
 
-            // Atomic write: a partially-written keystore would render every
-            // credential undecryptable, so this path is one we especially
-            // want crash-safe.
-            await AtomicFile.WriteAllBytesAsync(
+            // Atomic AND exclusive. Crash-safety is why this is a temp-then-rename
+            // (a half-written keystore would render every credential undecryptable);
+            // exclusivity is why it must not overwrite.
+            //
+            // Two first-run invocations can both find no keystore and both mint a data
+            // key — the ~200ms PBKDF2 derivation makes that window wide. If the second
+            // write replaced the first, every credential the first process had already
+            // encrypted would become permanently undecryptable. The loser instead
+            // discards its key and LoadOrCreateDataKeyAsync re-reads the winner's file,
+            // so both processes converge on one key and nothing is lost.
+            _ = await AtomicFile.TryWriteNewAsync(
                 _keyFile,
                 encryptedKey,
                 OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
@@ -44,6 +44,54 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             }
         }
 
+        /// <summary>
+        /// Writes <paramref name="bytes"/> to <paramref name="path"/> only if nothing is
+        /// there yet, and reports whether this call is the one that created it.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> when this call created the file; <see langword="false"/>
+        /// when another writer got there first, in which case the caller should read what
+        /// that writer left rather than assuming its own content is on disk.
+        /// </returns>
+        /// <remarks>
+        /// Same temp-then-rename shape as <see cref="WriteAllBytesAsync"/>, so the file is
+        /// still never observable half-written, but the final step is a non-overwriting
+        /// move. On both POSIX and Windows that throws when the destination already
+        /// exists, which is exactly the signal needed: the losing racer must not clobber
+        /// the winner. Used for the keystore, where an overwrite silently destroys every
+        /// credential already encrypted under the replaced key.
+        /// </remarks>
+        internal static async Task<bool> TryWriteNewAsync(string path, byte[] bytes, UnixFileMode? unixMode = null)
+        {
+            if (File.Exists(path))
+            {
+                return false;
+            }
+
+            var tempPath = BuildTempPath(path);
+            try
+            {
+                await File.WriteAllBytesAsync(tempPath, bytes).ConfigureAwait(false);
+                ApplyUnixModeIfRequested(tempPath, unixMode);
+
+                // Deliberately not overwrite:true. A racing creator that already landed
+                // its keystore must win; we then fall back to reading theirs.
+                File.Move(tempPath, path);
+                return true;
+            }
+            catch (IOException)
+            {
+                // Destination appeared between the check and the move: someone else won.
+                TryDelete(tempPath);
+                return false;
+            }
+            catch
+            {
+                TryDelete(tempPath);
+                throw;
+            }
+        }
+
         internal static async Task WriteAllBytesAsync(string path, byte[] bytes, UnixFileMode? unixMode = null)
         {
             var tempPath = BuildTempPath(path);

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Encryption/LocalFileCredentialEncryptionTests.cs
@@ -454,5 +454,47 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Encryption
                 Assert.Equal($"payload-{i}", results[i]);
             }
         }
+
+        [Fact]
+        public async Task ConcurrentFirstRun_BothWritersKeysSurvive()
+        {
+            using var temp = new TempDir();
+
+            // Two instances over one directory with no .keystore yet. There is no
+            // cross-process lock and no cross-instance lock either, so both take the
+            // create path and both derive a data key. Before the fix the second write
+            // replaced the first, and everything the first had already encrypted became
+            // permanently undecryptable (#44).
+            var a = new LocalFileCredentialEncryption(temp.Path);
+            var b = new LocalFileCredentialEncryption(temp.Path);
+
+            var encryptA = a.EncryptAsync("{\"secret\":\"WRITTEN-BY-A\"}");
+            var encryptB = b.EncryptAsync("{\"secret\":\"WRITTEN-BY-B\"}");
+            var cipherA = await encryptA;
+            var cipherB = await encryptB;
+
+            // A fresh instance is what the next CLI invocation gets: it reads whichever
+            // keystore is on disk. Both ciphertexts must open under it.
+            var reader = new LocalFileCredentialEncryption(temp.Path);
+            Assert.Equal("{\"secret\":\"WRITTEN-BY-A\"}", await reader.DecryptAsync(cipherA));
+            Assert.Equal("{\"secret\":\"WRITTEN-BY-B\"}", await reader.DecryptAsync(cipherB));
+        }
+
+        [Fact]
+        public async Task CreateKeyFile_DoesNotReplaceAnExistingKeystore()
+        {
+            using var temp = new TempDir();
+
+            var first = new LocalFileCredentialEncryption(temp.Path);
+            var cipher = await first.EncryptAsync("payload");
+
+            var keystore = Path.Join(temp.Path, ".keystore");
+            var bytesBefore = await File.ReadAllBytesAsync(keystore, TestContext.Current.CancellationToken);
+
+            // A second instance must adopt the existing keystore, never mint over it.
+            var second = new LocalFileCredentialEncryption(temp.Path);
+            Assert.Equal("payload", await second.DecryptAsync(cipher));
+            Assert.Equal(bytesBefore, await File.ReadAllBytesAsync(keystore, TestContext.Current.CancellationToken));
+        }
     }
 }


### PR DESCRIPTION
Fixes #44.

## What changed

Keystore creation is now exclusive as well as atomic. `AtomicFile` gains `TryWriteNewAsync` — the same temp-then-rename that keeps a half-written keystore unobservable, but with a **non-overwriting** `File.Move` as the final step.

## Why

Keystore creation was an unlocked check-then-write:

```csharp
if (!File.Exists(_keyFile)) { await CreateKeyFileAsync(); }   // AtomicFile replaced unconditionally
var stored = await File.ReadAllBytesAsync(_keyFile);
```

Two first-run invocations both find no `.keystore`, both spend ~200 ms deriving a KEK (600k PBKDF2 iterations — a wide window), and both write. If the first had already encrypted and persisted a credential under its key, the second's write made that credential **permanently undecryptable**.

It surfaced as the same *"failed integrity check"* message a keystore copied between machines produces, so it was easy to misdiagnose as user error — and it is a second, independent cause of the symptom reported in #38.

## Why this shape

`CreateKeyFileAsync` ignores the returned bool, because `LoadOrCreateDataKeyAsync` re-reads the file immediately afterwards regardless. That is what makes both interleavings safe: whoever loses the race discards their key and adopts the winner's, rather than persisting data under a key that is no longer on disk. Crash-safety is unchanged — only the final rename's overwrite behaviour differs.

A lock file was the alternative; this needs no new file and no stale-lock handling.

## Verification

Build clean, **362 tests** on both TFMs, up from 358.

The regression test is the original reproduction. Against the previous overwriting write it fails with the exact production error:

```
failed ... ConcurrentFirstRun_BothWritersKeysSurvive
  System.InvalidOperationException : Credential data failed integrity check. The file has been
  tampered with, or was encrypted with a different key (for example, the keystore was copied
  from another machine or user).
```

A second test pins that a later instance never replaces an existing keystore, comparing the file bytes before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
