### PR TITLE
fix: stop the libsecret suite disabling itself on regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The libsecret test suite disabled itself when the code it tests regressed** (#46). Its
+  availability probe performed a real store + clear through `AddCredentialAsync` /
+  `DeleteCredentialAsync` inside a catch-all, so a regression in exactly the code under test
+  made the probe throw, set the skip flag, and turn all ~20 tests into no-ops that still
+  reported as passing. The probe now uses the interop layer directly — a read-only search
+  against attributes nothing can match — and touches no part of the manager. Sabotaging
+  `AddCredentialAsync` now produces 46 failures where it previously produced none.
+  Platform-guarded tests in both the libsecret and Keychain suites also report as **skipped**
+  instead of returning early and counting as passed, so a run that verifies nothing says so:
+  50 skipped on Linux where the total previously read `skipped: 0`.
+
 - **Two concurrent first runs could silently destroy one set of credentials** (#44). Keystore
   creation was an unlocked check-then-write: both invocations found no `.keystore`, both spent
   ~200ms deriving a KEK, and the second write replaced the first via an unconditional atomic

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -26,6 +26,10 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         private readonly string _appIdentifier;
         private readonly bool _skip;
 
+        // Reported as a real skip rather than an early return, so a non-macOS run
+        // shows up as skipped instead of silently passing.
+        private const string SkipReason = "macOS is required for the Keychain backend.";
+
         public KeychainCredentialManagerTests()
         {
             _skip = !OperatingSystem.IsMacOS();
@@ -34,7 +38,9 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
 
         public void Dispose()
         {
-            // Best-effort cleanup: delete everything this test added.
+            // Best-effort cleanup: delete everything this test added. Not a skip point —
+            // Dispose runs after a skipped test too, and throwing the dynamic-skip
+            // exception here surfaces as a failure rather than a skip.
             if (_skip)
             {
                 return;
@@ -73,10 +79,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ExportCredentialsAsync_ReturnsDecryptedPayloadAndSelection()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
@@ -101,10 +104,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         {
             // The macOS Keychain assigns its own creation date, so CreatedAt is
             // intentionally not asserted here (see RestoreCredentialAsync remarks).
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
@@ -124,10 +124,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task AddCredentialAsync_ReturnsGuidAccountId()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -139,10 +136,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ListCredentialsAsync_ReturnsAddedCredential()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -160,10 +154,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ListCredentialsAsync_FiltersByProvider()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "a1", "Production", "{}");
@@ -181,10 +172,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task SelectAndGetSelected_RoundTripsDecryptedPayload()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var payload = "{\"apiKey\":\"super-secret\"}";
@@ -199,10 +187,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task SelectCredentialAsync_ReturnsFalse_WhenNotFound()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -214,10 +199,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetSelectedCredentialAsync_ReturnsNull_WhenNoneSelected()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -230,10 +212,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_ReturnsDecryptedPayload_ForExistingAccount()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var payload = "{\"apiKey\":\"super-secret\"}";
@@ -247,10 +226,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_ReturnsNull_ForUnknownAccountId()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -263,10 +239,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_DoesNotMutateSelection()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var selectedId = await manager.AddCredentialAsync("Adobe", "selected", "Production", "{\"a\":1}");
@@ -283,10 +256,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_ReturnsNull_WhenProviderMismatches()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var adobeId = await manager.AddCredentialAsync("Adobe", "adobe-acct", "Production", "{}");
@@ -299,10 +269,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task DeleteCredentialAsync_RemovesCredential()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -317,10 +284,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task DeleteCredentialAsync_ClearsSelection_IfItWasSelected()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -334,10 +298,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task DeleteCredentialAsync_ReturnsFalse_WhenNotFound()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -349,10 +310,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetProviderNamesAsync_ReturnsDistinctProviders()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "a1", "Production", "{}");
@@ -369,10 +327,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task Credentials_AreIsolated_ByAppIdentifier()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             // Create a neighbour app that shouldn't see our items.
             var neighbourIdentifier = $"test.nextiteration.sca.neighbour.{Guid.NewGuid():N}";
@@ -408,10 +363,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [InlineData("pro vider")]
         public async Task AddCredentialAsync_InvalidProviderName_Throws(string providerName)
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -422,10 +374,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public void Constructor_NullAppIdentifier_Throws()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 #pragma warning disable CA1416
             Assert.ThrowsAny<ArgumentException>(() => new KeychainCredentialManager(null!));
 #pragma warning restore CA1416
@@ -434,10 +383,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public void Constructor_EmptyAppIdentifier_Throws()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 #pragma warning disable CA1416
             Assert.ThrowsAny<ArgumentException>(() => new KeychainCredentialManager(""));
 #pragma warning restore CA1416
@@ -446,10 +392,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ListCredentialsAsync_IncludesDisplayFields_FromSummaryProvider()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var summaryProvider = new FakeAdobeSummaryProvider();
             var manager = NewManager([summaryProvider]);

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -34,6 +34,11 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
     {
         private const string TestCollection = "session";
 
+        // Reported as a real skip rather than an early return, so an environment
+        // without a Secret Service shows up as skipped instead of silently passing.
+        private const string SkipReason =
+            "Linux with a reachable Secret Service daemon is required; see the libsecret setup in ci.yml.";
+
         private readonly string _appIdentifier;
         private readonly bool _skip;
 
@@ -44,12 +49,22 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         }
 
         /// <summary>
-        /// Best-effort probe: try a store + clear against the session collection
-        /// and treat any exception as "Secret Service isn't available." A bare
-        /// search doesn't exercise the collection write path, so we do a real
-        /// round-trip. Not running on Linux counts as unavailable too so the
-        /// test class compiles clean on any platform.
+        /// Probes whether a Secret Service daemon is reachable, using the interop layer
+        /// directly and touching <b>no</b> part of <see cref="LibsecretCredentialManager"/>.
         /// </summary>
+        /// <remarks>
+        /// This deliberately does not go through the manager. The previous probe performed
+        /// a real store + clear via <c>AddCredentialAsync</c>/<c>DeleteCredentialAsync</c>
+        /// inside a catch-all, so a regression in the very code these tests exist to cover
+        /// made the probe throw, set <c>_skip</c>, and turn all ~20 tests into silent
+        /// no-ops that still reported as passing (#46). The more broken the backend, the
+        /// quieter the suite.
+        /// <para>
+        /// A read-only search against an attribute set that cannot match anything is enough
+        /// to tell "no daemon" from "daemon present", and it stays true regardless of what
+        /// the manager does.
+        /// </para>
+        /// </remarks>
         private static bool IsSecretServiceAvailable()
         {
             if (!OperatingSystem.IsLinux())
@@ -59,16 +74,42 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
 
             try
             {
-#pragma warning disable CA1416
-                var probe = new LibsecretCredentialManager(
-                    $"probe.{Guid.NewGuid():N}",
-                    collection: TestCollection);
-                var id = probe.AddCredentialAsync("Probe", "probe", "Probe", "{}").GetAwaiter().GetResult();
-                _ = probe.DeleteCredentialAsync(id).GetAwaiter().GetResult();
-#pragma warning restore CA1416
-                return true;
+                var attrs = LibsecretInterop.NewAttributes(new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    // A value no stored item can carry, so the search matches nothing and
+                    // the call is purely an availability check.
+                    ["nextIteration.sca.probe"] = Guid.NewGuid().ToString("N"),
+                });
+
+                try
+                {
+                    var list = LibsecretInterop.secret_password_searchv_sync(
+                        IntPtr.Zero, attrs, LibsecretInterop.SecretSearchAll, IntPtr.Zero, out var error);
+
+                    if (error != IntPtr.Zero)
+                    {
+                        LibsecretInterop.g_error_free(error);
+                        return false;
+                    }
+
+                    if (list != IntPtr.Zero)
+                    {
+                        LibsecretInterop.g_list_free(list);
+                    }
+
+                    return true;
+                }
+                finally
+                {
+                    LibsecretInterop.g_hash_table_unref(attrs);
+                }
             }
-            catch
+            catch (DllNotFoundException)
+            {
+                // libsecret-1.so.0 not installed.
+                return false;
+            }
+            catch (EntryPointNotFoundException)
             {
                 return false;
             }
@@ -114,10 +155,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ExportCredentialsAsync_ReturnsDecryptedPayloadAndSelection()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
@@ -135,10 +173,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task RestoreCredentialAsync_PreservesAccountIdCreatedAtAndSelection()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"secret\"}");
@@ -159,10 +194,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task AddCredentialAsync_ReturnsGuidAccountId()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -174,10 +206,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ListCredentialsAsync_ReturnsAddedCredential()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -195,10 +224,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ListCredentialsAsync_FiltersByProvider()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "a1", "Production", "{}");
@@ -214,10 +240,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task SelectAndGetSelected_RoundTripsDecryptedPayload()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var payload = "{\"apiKey\":\"super-secret\"}";
@@ -232,10 +255,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task SelectCredentialAsync_ReturnsFalse_WhenNotFound()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -247,10 +267,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetSelectedCredentialAsync_ReturnsNull_WhenNoneSelected()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -263,10 +280,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_ReturnsDecryptedPayload_ForExistingAccount()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var payload = "{\"apiKey\":\"super-secret\"}";
@@ -280,10 +294,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_ReturnsNull_ForUnknownAccountId()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -296,10 +307,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_DoesNotMutateSelection()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var selectedId = await manager.AddCredentialAsync("Adobe", "selected", "Production", "{\"a\":1}");
@@ -316,10 +324,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetCredentialByIdAsync_ReturnsNull_WhenProviderMismatches()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var adobeId = await manager.AddCredentialAsync("Adobe", "adobe-acct", "Production", "{}");
@@ -332,10 +337,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task DeleteCredentialAsync_RemovesCredential()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -350,10 +352,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task DeleteCredentialAsync_ClearsSelection_IfItWasSelected()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
@@ -367,10 +366,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task DeleteCredentialAsync_ReturnsFalse_WhenNotFound()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -382,10 +378,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task GetProviderNamesAsync_ReturnsDistinctProviders()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             _ = await manager.AddCredentialAsync("Adobe", "a1", "Production", "{}");
@@ -402,10 +395,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task Credentials_AreIsolated_ByAppIdentifier()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var neighbourIdentifier = $"test.nextiteration.sca.neighbour.{Guid.NewGuid():N}";
 #pragma warning disable CA1416
@@ -439,10 +429,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [InlineData("pro vider")]
         public async Task AddCredentialAsync_InvalidProviderName_Throws(string providerName)
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
 
@@ -465,10 +452,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [Fact]
         public async Task ListCredentialsAsync_IncludesDisplayFields_FromSummaryProvider()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var summaryProvider = new FakeAdobeSummaryProvider();
             var manager = NewManager([summaryProvider]);
@@ -491,10 +475,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [SupportedOSPlatform("linux")]
         public async Task ListCredentialsAsync_NoSummaryProvider_ReportsDecryptable()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager(); // no summary provider
 
@@ -511,10 +492,7 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
         [SupportedOSPlatform("linux")]
         public async Task ExportCredentialsAsync_CarriesTheRealSecret()
         {
-            if (_skip)
-            {
-                return;
-            }
+            Assert.SkipWhen(_skip, SkipReason);
 
             var manager = NewManager();
             var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"xyz\"}");


### PR DESCRIPTION
Fixes #46.

## What changed

Two separable things, both about a green run meaning something:

1. **The libsecret availability probe no longer runs the code under test.** It now uses `LibsecretInterop` directly — a read-only `secret_password_searchv_sync` against an attribute set nothing can match — and touches no part of `LibsecretCredentialManager`.
2. **Platform-guarded tests report as skipped** in both the libsecret and Keychain suites, via `Assert.SkipWhen`, instead of returning early and counting as passed.

## Why

The old probe performed a real store + clear through `AddCredentialAsync` / `DeleteCredentialAsync` inside a `catch { return false; }`. So a regression in exactly the code these tests exist to cover made the probe throw, set `_skip`, and turned all ~20 tests into silent no-ops that still reported as passing. The more broken the backend, the quieter the suite — the inverse of what a harness should do.

## Verification

Sabotaging `AddCredentialAsync` with a thrown exception:

| | failures |
|---|---|
| before this PR | **0** — suite self-disabled and reported green |
| after this PR | **46** |

And the skip counts on Linux, which are the second half of the point:

```
before:  358 passed,   0 skipped      <- 50 of those verified nothing
after:   312 passed,  50 skipped
```

Those 50 Keychain tests were always vacuous off-macOS; now the run says so instead of inflating the pass count. Full suite: 362 total, 0 failed.

## Notes

- `Dispose` deliberately keeps its early return in both suites. It runs after a skipped test too, and throwing the dynamic-skip exception there surfaces as an `AggregateException` failure rather than a skip — which is exactly what happened on my first attempt.
- The Keychain suite's own probe was already fine (`!OperatingSystem.IsMacOS()`, no production code), so only libsecret needed the probe change. It is included in the skip change because leaving one suite silently passing while fixing the other would be arbitrary.
- Residual, stated plainly: the probe still depends on libsecret's *interop* layer loading. If `libsecret-1.so.0` is absent the suite skips, which is correct — but a regression inside `LibsecretInterop` itself could still mask the suite. Decoupling from that too would mean not using libsecret to detect libsecret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
