### PR TITLE
fix: a throwing summary provider must not erase the credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A summary provider that threw made the whole credential vanish from `accounts list`**
+  (#52). The per-file `catch (JsonException)` in `FileCredentialManager.ListCredentialsAsync`
+  spanned the entire loop body, including the consumer's `GetDisplayFields` call. Since the
+  README's own worked example projects with `System.Text.Json`, a payload shape it could not
+  parse threw `JsonException` and the credential was silently dropped from the listing — not
+  marked, not counted, just absent, which also hid the id needed to run `accounts delete` on
+  it. The JSON catch is now scoped to the deserialize step, and the projection is guarded
+  separately: a throwing provider costs that row its provider columns and marks it
+  `IsDecryptable = false`, never its existence. `IsDecryptable`'s documentation is widened to
+  match — it now means "this row's provider columns could not be produced", covering both an
+  unavailable payload and a projection that threw.
+
 - **The libsecret test suite disabled itself when the code it tests regressed** (#46). Its
   availability probe performed a real store + clear through `AddCredentialAsync` /
   `DeleteCredentialAsync` inside a catch-all, so a regression in exactly the code under test

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
@@ -66,62 +66,72 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
 
             foreach (var file in credentialFiles)
             {
+                StoredCredential? credential;
                 try
                 {
                     var content = await File.ReadAllTextAsync(file).ConfigureAwait(false);
-                    var credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
-
-                    // Defensive re-check: the glob should only match this
-                    // provider's files, but if a stray file sneaks in we want
-                    // to ignore it rather than report a mis-attributed row.
-                    // `is not null` (rather than `?.… == true`) so the null
-                    // state flows into the block — the whole body dereferences
-                    // `credential`, and this lets the analyzer prove it safe.
-                    if (credential is not null &&
-                        credential.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        var isSelected = selections.TryGetValue($"{credential.ProviderName}", out var selectedId) &&
-                                       selectedId.Equals(credential.AccountId, StringComparison.OrdinalIgnoreCase);
-
-                        IReadOnlyList<KeyValuePair<string, string>> displayFields = [];
-                        var isDecryptable = true;
-                        if (summaryProvider is not null)
-                        {
-                            try
-                            {
-                                var decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
-                                displayFields = summaryProvider.GetDisplayFields(decrypted);
-                            }
-                            catch (InvalidOperationException)
-                            {
-                                // The payload cannot be opened with this machine's
-                                // keystore — typically a credentials directory copied
-                                // from another machine or user, or a keystore that was
-                                // replaced while its credential files survived. Render
-                                // the row without provider columns rather than taking
-                                // down the whole listing: the user needs to see the id
-                                // to remove it with `accounts delete`.
-                                isDecryptable = false;
-                            }
-                        }
-
-                        credentials.Add(new CredentialSummary
-                        {
-                            AccountId = credential.AccountId,
-                            AccountName = credential.AccountName,
-                            ProviderName = credential.ProviderName,
-                            Environment = credential.Environment,
-                            CreatedAt = credential.CreatedAt,
-                            IsSelected = isSelected,
-                            DisplayFields = displayFields,
-                            IsDecryptable = isDecryptable,
-                        });
-                    }
+                    credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
                 }
                 catch (JsonException)
                 {
-                    // Skip invalid JSON files
+                    // Skip invalid JSON files. Scoped to the deserialize step on purpose:
+                    // this catch used to span the whole body, including the consumer's
+                    // GetDisplayFields call, so a summary provider that threw JsonException
+                    // silently removed the credential from the listing entirely (#52).
+                    continue;
                 }
+
+                // Defensive re-check: the glob should only match this provider's files,
+                // but if a stray file sneaks in we want to ignore it rather than report
+                // a mis-attributed row.
+                if (credential is null ||
+                    !credential.ProviderName.Equals(providerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var isSelected = selections.TryGetValue($"{credential.ProviderName}", out var selectedId) &&
+                               selectedId.Equals(credential.AccountId, StringComparison.OrdinalIgnoreCase);
+
+                IReadOnlyList<KeyValuePair<string, string>> displayFields = [];
+                var isRenderable = true;
+                if (summaryProvider is not null)
+                {
+                    try
+                    {
+                        var decrypted = await _encryption.DecryptAsync(credential.CredentialData).ConfigureAwait(false);
+                        displayFields = summaryProvider.GetDisplayFields(decrypted);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // The payload cannot be opened with this machine's keystore —
+                        // typically a credentials directory copied from another machine or
+                        // user, or a keystore replaced while its credential files survived.
+                        isRenderable = false;
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        // GetDisplayFields is consumer code and can throw anything; the
+                        // README's own worked example deserializes with System.Text.Json,
+                        // so an old payload shape throws JsonException here. A broken
+                        // projection must cost this row its provider columns, never its
+                        // existence — the user still needs the id to run `accounts delete`.
+                        displayFields = [];
+                        isRenderable = false;
+                    }
+                }
+
+                credentials.Add(new CredentialSummary
+                {
+                    AccountId = credential.AccountId,
+                    AccountName = credential.AccountName,
+                    ProviderName = credential.ProviderName,
+                    Environment = credential.Environment,
+                    CreatedAt = credential.CreatedAt,
+                    IsSelected = isSelected,
+                    DisplayFields = displayFields,
+                    IsDecryptable = isRenderable,
+                });
             }
 
             return credentials.OrderBy(c => c.AccountName);

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
@@ -160,11 +160,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         public IReadOnlyList<KeyValuePair<string, string>> DisplayFields { get; init; } = [];
 
         /// <summary>
-        /// Display hint: <see langword="false"/> when the stored payload was asked
-        /// for and could not be produced — it failed to decrypt (file backend) or did
-        /// not load from the OS store (Keychain, libsecret) — so
-        /// <see cref="DisplayFields"/> is empty for that reason rather than because no
-        /// summary provider is registered.
+        /// Display hint: <see langword="false"/> when this credential's provider
+        /// columns could not be produced, so <see cref="DisplayFields"/> is empty for
+        /// that reason rather than because no summary provider is registered. Either
+        /// the payload itself was unavailable — it failed to decrypt (file backend) or
+        /// did not load from the OS store (Keychain, libsecret) — or the registered
+        /// <see cref="ICredentialSummaryProvider"/> threw while projecting it.
         /// </summary>
         /// <remarks>
         /// This is not a guarantee that the payload <em>is</em> readable. The

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -706,6 +706,53 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
                 () => manager.GetCredentialByIdAsync("Adobe", badId));
         }
 
+        [Fact]
+        public async Task ListCredentialsAsync_SummaryProviderThrows_StillListsTheCredential()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path, [new ThrowingAdobeSummaryProvider()]);
+
+            var goodId = await manager.AddCredentialAsync("Adobe", "keeps-row", "Production", "{}");
+
+            // The projection throws JsonException, which the outer per-file catch used to
+            // swallow along with the whole credential — the row vanished from `accounts
+            // list`, so the user could not even see the id to delete it (#52).
+            var listed = (await manager.ListCredentialsAsync("Adobe")).ToList();
+
+            var only = Assert.Single(listed);
+            Assert.Equal(goodId, only.AccountId);
+            Assert.Equal("keeps-row", only.AccountName);
+            Assert.Empty(only.DisplayFields);
+            Assert.False(only.IsDecryptable);
+        }
+
+        [Fact]
+        public async Task ListCredentialsAsync_SummaryProviderThrows_DoesNotAffectOtherRows()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path, [new ThrowingAdobeSummaryProvider()]);
+
+            _ = await manager.AddCredentialAsync("Adobe", "a", "Production", "{}");
+            _ = await manager.AddCredentialAsync("Adobe", "b", "Production", "{}");
+
+            // One bad projection must not take down the provider's whole listing.
+            Assert.Equal(2, (await manager.ListCredentialsAsync("Adobe")).Count());
+        }
+
+        /// <summary>
+        /// Stands in for a consumer whose projection cannot parse a stored payload —
+        /// e.g. one written by an older version of that provider package. The README's
+        /// own worked example uses System.Text.Json, so JsonException is the realistic
+        /// throw here.
+        /// </summary>
+        private sealed class ThrowingAdobeSummaryProvider : ICredentialSummaryProvider
+        {
+            public string ProviderName => "Adobe";
+
+            public IReadOnlyList<KeyValuePair<string, string>> GetDisplayFields(string decryptedCredentialJson) =>
+                throw new System.Text.Json.JsonException("provider cannot parse this payload shape");
+        }
+
         /// <summary>
         /// Minimal summary provider used only to verify that
         /// <see cref="FileCredentialManager.ListCredentialsAsync"/> routes


### PR DESCRIPTION
Fixes #52.

## What changed

The per-file `catch (JsonException)` in `FileCredentialManager.ListCredentialsAsync` is scoped to the deserialize step, and the consumer's `GetDisplayFields` call is guarded separately.

## Why

The catch used to span the whole loop body — read, deserialize, decrypt **and** the projection. `GetDisplayFields` is consumer code, and the README's own worked example implements it with `System.Text.Json`, so a payload shape it cannot parse (one written by an older version of that provider package, say) throws `JsonException` and the credential was **silently dropped from the listing**. Not marked, not counted, just absent — which also hid the id needed to run `accounts delete` on it.

That is the same can't-see-it-to-fix-it trap #38 addressed, arrived at from the other direction. It survived that fix because the guard added there catches `InvalidOperationException` from `DecryptAsync`, not `JsonException` from the projection.

## Semantic choice worth reviewing

A throwing projection now sets `IsDecryptable = false`, and I widened that property's documentation to *"this row's provider columns could not be produced"* — covering both an unavailable payload and a projection that threw.

The alternative was a second flag. I judged one accurate-but-broader flag better than two, since the CLI's use is identical either way (mark the row `(unreadable)`), but it does mean the name is now slightly narrower than the meaning. Say the word if you'd rather it were split.

`OperationCanceledException` is deliberately excluded from the guard.

## Verification

Build clean, **366 tests** on both TFMs (316 passed, 50 skipped), up from 362.

Both new tests fail against the previous behaviour — verified by excluding `JsonException` from the new guard, which reproduces the old swallow:

```
failed ... ListCredentialsAsync_SummaryProviderThrows_StillListsTheCredential
failed ... ListCredentialsAsync_SummaryProviderThrows_DoesNotAffectOtherRows
```

The second one matters independently: it pins that one bad projection cannot take down its provider's *other* rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
