### PR TITLE
fix: key the selection map case-insensitively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`accounts list` could show a credential as selected that the consumer could not resolve**
+  (#48). `selections.json` deserialised into a default ordinal dictionary, so
+  `GetSelectedCredentialAsync` missed a selection recorded under a differently-cased provider
+  spelling — while `ListCredentialsAsync`, which matches `OrdinalIgnoreCase`, still reported
+  that same credential as selected. The result was a green tick in the listing next to
+  "No credential selected" from the consumer's `AuthenticateAsync()`. The selection map is now
+  keyed `OrdinalIgnoreCase`, matching every other provider comparison in the class, and a
+  hand-edited file holding two spellings of one provider is tolerated rather than throwing.
+
 - **A summary provider that threw made the whole credential vanish from `accounts list`**
   (#52). The per-file `catch (JsonException)` in `FileCredentialManager.ListCredentialsAsync`
   spanned the entire loop body, including the consumer's `GetDisplayFields` call. Since the

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
@@ -496,23 +496,52 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
 
         private void EnsureDirectoryExists() => CredentialsDirectory.Ensure(_credentialsDirectory);
 
+        /// <summary>
+        /// Loads the provider-to-account-id selection map, keyed case-insensitively.
+        /// </summary>
+        /// <remarks>
+        /// The comparer is load-bearing. Every other provider-name comparison in this
+        /// class is <see cref="StringComparison.OrdinalIgnoreCase"/> and the file glob is
+        /// lowercased, but the selection map deserialised into a default (ordinal)
+        /// dictionary — so <see cref="GetSelectedCredentialAsync"/> missed a selection
+        /// stored under a differently-cased spelling while
+        /// <see cref="ListCredentialsAsync"/> still reported that same credential as
+        /// selected. A green tick in `accounts list` alongside "no credential selected"
+        /// from the consumer's authenticate call (#48).
+        /// </remarks>
         private async Task<Dictionary<string, string>> LoadSelectionsAsync()
         {
             if (!File.Exists(_selectionFile))
             {
-                return [];
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
 
+            Dictionary<string, string>? loaded;
             try
             {
                 var content = await File.ReadAllTextAsync(_selectionFile).ConfigureAwait(false);
-                return JsonSerializer.Deserialize<Dictionary<string, string>>(content, _jsonOptions) ??
-                       [];
+                loaded = JsonSerializer.Deserialize<Dictionary<string, string>>(content, _jsonOptions);
             }
             catch (JsonException)
             {
-                return [];
+                loaded = null;
             }
+
+            var selections = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (loaded is null)
+            {
+                return selections;
+            }
+
+            foreach (var (provider, accountId) in loaded)
+            {
+                // TryAdd rather than the indexer: a hand-edited selections.json can hold
+                // two keys differing only by case, which would throw on a case-insensitive
+                // dictionary. First wins, matching the file-enumeration order elsewhere.
+                _ = selections.TryAdd(provider, accountId);
+            }
+
+            return selections;
         }
 
         private async Task SaveSelectionsAsync(Dictionary<string, string> selections)

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -753,6 +753,46 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
                 throw new System.Text.Json.JsonException("provider cannot parse this payload shape");
         }
 
+        [Theory]
+        [InlineData("Adobe")]
+        [InlineData("adobe")]
+        [InlineData("ADOBE")]
+        public async Task GetSelectedCredentialAsync_IsCaseInsensitive_LikeListCredentials(string spelling)
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+
+            // Stored under the canonical spelling.
+            var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"v\"}");
+            Assert.True(await manager.SelectCredentialAsync(id));
+
+            // ListCredentialsAsync has always matched case-insensitively; the selection
+            // lookup did not, so it returned null for exactly the credential the listing
+            // was reporting as selected (#48).
+            var listed = Assert.Single(await manager.ListCredentialsAsync(spelling));
+            Assert.True(listed.IsSelected);
+            Assert.Equal("{\"k\":\"v\"}", await manager.GetSelectedCredentialAsync(spelling));
+        }
+
+        [Fact]
+        public async Task LoadSelections_ToleratesCaseDuplicatesInAHandEditedFile()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+            var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
+            Assert.True(await manager.SelectCredentialAsync(id));
+
+            // A case-insensitive dictionary throws on duplicate keys, so a hand-edited
+            // file holding both spellings must not take the store down.
+            var selectionFile = Path.Join(temp.Path, "selections.json");
+            await File.WriteAllTextAsync(
+                selectionFile,
+                $"{{\"Adobe\":\"{id}\",\"adobe\":\"{id}\"}}",
+                TestContext.Current.CancellationToken);
+
+            Assert.Equal("{}", await manager.GetSelectedCredentialAsync("Adobe"));
+        }
+
         /// <summary>
         /// Minimal summary provider used only to verify that
         /// <see cref="FileCredentialManager.ListCredentialsAsync"/> routes


### PR DESCRIPTION
Fixes #48.

## What changed

`FileCredentialManager.LoadSelectionsAsync` builds the provider-to-account-id map with `StringComparer.OrdinalIgnoreCase`.

## Why

The selection lookup was the **only** case-sensitive provider-name comparison in the class. Everything else — the defensive re-check in `ListCredentialsAsync`, the file glob, the summary-provider dictionary — is `OrdinalIgnoreCase`. So a selection stored under `Adobe` was invisible to `GetSelectedCredentialAsync("adobe")`, while the listing still reported that credential as selected:

```
provider="Adobe " list=1 IsSelected=True  GetSelectedCredentialAsync=payload
provider="adobe " list=1 IsSelected=True  GetSelectedCredentialAsync=NULL
provider="ADOBE " list=1 IsSelected=True  GetSelectedCredentialAsync=NULL
```

A green tick in `accounts list` beside *"No credential selected"* from the consumer's `AuthenticateAsync()` is about the worst pair of signals to debug from.

## Note on the duplicate-key edge

A case-insensitive dictionary throws on duplicate keys, and `selections.json` is a plain file a user can edit. Entries are copied with `TryAdd` rather than the indexer so a file holding both `Adobe` and `adobe` degrades to first-wins instead of taking the whole store down on load. A test pins that.

## Verification

Build clean, **374 tests** (324 passed, 50 skipped), up from 366. The theory covers all three spellings and asserts the listing and the lookup now agree.

Related: #49 is the same question across the three backends, where the divergence is between implementations rather than inside one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
