### PR TITLE
fix: match provider names case-insensitively on every backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Provider-name casing behaved differently on each of the three backends** (#49).
+  `ICredentialManager` documented no case-sensitivity contract, and the implementations
+  disagreed: the file backend matched `OrdinalIgnoreCase`, while the Keychain and libsecret
+  backends keyed every lookup on the caller's exact spelling. A consumer developed against
+  the default file backend that passed a differently-cased provider name worked there and
+  silently returned nothing once `UseKeychain` or `UseKeyring` was set. The contract is now
+  stated on `ICredentialManager` — **provider names are matched case-insensitively and stored
+  as supplied** — and both OS backends honour it by resolving the caller's spelling to the
+  stored one. Resolution rather than normalisation, deliberately: the provider name is part
+  of those backends' storage keys, so lowercasing the key would orphan every item already
+  stored under a mixed-case spelling. One difference is documented rather than fixed — a store
+  holding two spellings of one provider lists both on the file backend and one on the native
+  backends, which the normal path cannot produce.
+
 - **`accounts list` could show a credential as selected that the consumer could not resolve**
   (#48). `selections.json` deserialised into a default ordinal dictionary, so
   `GetSelectedCredentialAsync` missed a selection recorded under a differently-cased provider

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
@@ -7,6 +7,25 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
     /// implementation is <see cref="FileCredentialManager"/>, registered
     /// automatically by <c>AddCredentialStore</c>.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Provider names are matched case-insensitively</b> and stored as supplied.
+    /// A credential added as <c>Adobe</c> is found by a lookup for <c>adobe</c>, and
+    /// the spelling the caller used is what <see cref="CredentialSummary.ProviderName"/>
+    /// reports back. Implementations must honour this: it was previously unstated, and
+    /// the three shipped backends disagreed — the file backend matched case-insensitively
+    /// while the Keychain and libsecret backends keyed on the exact spelling, so the same
+    /// call returned a credential on one backend and nothing on another (#49).
+    /// </para>
+    /// <para>
+    /// One documented difference remains between backends. If a store somehow holds two
+    /// spellings of the same provider (<c>Adobe</c> and <c>adobe</c> both added), the file
+    /// backend lists credentials under both, while the OS-native backends resolve to one
+    /// stored spelling and list only that one. Reaching that state requires deliberately
+    /// adding a provider twice under different casing; the normal path cannot, because a
+    /// provider's name comes from a single <c>ICredential.ProviderName</c> constant.
+    /// </para>
+    /// </remarks>
     public interface ICredentialManager
     {
         /// <summary>

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
@@ -112,6 +112,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         public Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName)
         {
             ValidateProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName);
             var service = ServiceFor(providerName);
             _summaryProviders.TryGetValue(providerName, out var summaryProvider);
 
@@ -201,6 +202,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         public Task<string?> GetSelectedCredentialAsync(string providerName)
         {
             ValidateProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName);
             var selectedId = ReadSelection(providerName);
             if (selectedId is null)
             {
@@ -214,6 +216,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         public Task<string?> GetCredentialByIdAsync(string providerName, string accountId)
         {
             ValidateProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName);
             ValidateAccountId(accountId);
 
             return Task.FromResult(ReadItemDataById(providerName, accountId));
@@ -354,6 +357,39 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         // =========================
         // Internal helpers
         // =========================
+
+        /// <summary>
+        /// Maps a caller-supplied provider name onto the spelling this store actually
+        /// used, so lookups match case-insensitively like the file backend's do.
+        /// </summary>
+        /// <remarks>
+        /// Resolution rather than normalisation is deliberate. The provider name is part
+        /// of this backend's storage key, so lowercasing the key would orphan every item
+        /// already stored under a mixed-case spelling. Resolving instead leaves the stored
+        /// format untouched: the caller's spelling is matched against what is on disk and
+        /// the stored spelling is used for the query. Falls back to the caller's spelling
+        /// when nothing matches, so a genuine miss still behaves as a miss (#49).
+        /// </remarks>
+        private string ResolveStoredProviderName(string providerName)
+        {
+            var providerPrefix = _appIdentifier + ".";
+            foreach (var item in QueryAllItemsForApp(includeData: false))
+            {
+                if (!item.Service.StartsWith(providerPrefix, StringComparison.Ordinal) ||
+                    item.Service.EndsWith(SelectionsServiceSuffix, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var stored = item.Service[providerPrefix.Length..];
+                if (stored.Equals(providerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return stored;
+                }
+            }
+
+            return providerName;
+        }
 
         private string ServiceFor(string providerName) => $"{_appIdentifier}.{providerName}";
 

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
@@ -128,6 +128,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         public Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName)
         {
             ValidateProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName);
             _summaryProviders.TryGetValue(providerName, out var summaryProvider);
 
             var selectedId = ReadSelection(providerName);
@@ -245,6 +246,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         public Task<string?> GetSelectedCredentialAsync(string providerName)
         {
             ValidateProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName);
             var selectedId = ReadSelection(providerName);
             if (selectedId is null)
             {
@@ -258,6 +260,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         public Task<string?> GetCredentialByIdAsync(string providerName, string accountId)
         {
             ValidateProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName);
             ValidateAccountId(accountId);
 
             return Task.FromResult(LookupCredentialByAccountId(providerName, accountId));
@@ -451,6 +454,41 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                 out var parsed)
                 ? parsed
                 : DateTime.MinValue;
+        }
+
+        /// <summary>
+        /// Maps a caller-supplied provider name onto the spelling this store actually
+        /// used, so lookups match case-insensitively like the file backend's do.
+        /// </summary>
+        /// <remarks>
+        /// Resolution rather than normalisation is deliberate. The provider name is part
+        /// of this backend's storage key, so lowercasing the key would orphan every item
+        /// already stored under a mixed-case spelling. Resolving instead leaves the stored
+        /// format untouched: the caller's spelling is matched against what is on disk and
+        /// the stored spelling is used for the query. Falls back to the caller's spelling
+        /// when nothing matches, so a genuine miss still behaves as a miss (#49).
+        /// </remarks>
+        private string ResolveStoredProviderName(string providerName)
+        {
+            var items = SearchItems(
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [AttrApp] = _appIdentifier,
+                    [AttrKind] = KindCredential,
+                },
+                loadSecrets: false);
+
+            foreach (var item in items)
+            {
+                var stored = item.Attributes.GetValueOrDefault(AttrProvider);
+                if (!string.IsNullOrEmpty(stored) &&
+                    stored.Equals(providerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return stored;
+                }
+            }
+
+            return providerName;
         }
 
         private static void ValidateProviderName(string providerName)

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -512,6 +512,28 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.NotEqual(string.Empty, exported.CredentialData);
         }
 
+        [Theory]
+        [InlineData("Adobe")]
+        [InlineData("adobe")]
+        [InlineData("ADOBE")]
+        [SupportedOSPlatform("linux")]
+        public async Task ProviderLookups_AreCaseInsensitive(string spelling)
+        {
+            Assert.SkipWhen(_skip, SkipReason);
+
+            var manager = NewManager();
+            var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"v\"}");
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(id)));
+
+            // The OS backends keyed every lookup on the caller's exact spelling, so a
+            // consumer that worked against the file backend returned nothing here (#49).
+            var listed = Assert.Single(
+                await RetryHelper.UntilAsync(() => manager.ListCredentialsAsync(spelling), r => r.Count() == 1));
+            Assert.Equal(id, listed.AccountId);
+            Assert.Equal("{\"k\":\"v\"}", await manager.GetSelectedCredentialAsync(spelling));
+            Assert.Equal("{\"k\":\"v\"}", await manager.GetCredentialByIdAsync(spelling, id));
+        }
+
         private sealed class FakeAdobeSummaryProvider : ICredentialSummaryProvider
         {
             public string ProviderName => "Adobe";


### PR DESCRIPTION
Fixes #49.

## What changed

`ICredentialManager` now states the contract — **provider names are matched case-insensitively and stored as supplied** — and the two OS-native backends honour it.

## Why

The interface was silent on case-sensitivity, so neither behaviour was wrong against the spec — which is itself the defect. The implementations diverged:

| Backend | Behaviour |
|---|---|
| File (default) | lowercases the filename prefix, compares `OrdinalIgnoreCase` |
| Keychain | `ServiceFor` = `$"{_appIdentifier}.{providerName}"`, matched exactly |
| libsecret | provider stored verbatim in `nextIteration.sca.provider`, matched exactly |

A consumer developed against the default backend that passed a differently-cased provider name worked on file and silently returned **nothing** once `UseKeychain` or `UseKeyring` was set.

## Resolution, not normalisation

The obvious fix — lowercase the key — would **orphan every item already stored** under a mixed-case spelling, since the provider name is part of the storage key on both native backends. So instead the caller's spelling is resolved against what is actually stored, and the stored spelling is used for the query. No format change, no migration, existing stores keep working.

Applied at the three read entry points (`ListCredentialsAsync`, `GetSelectedCredentialAsync`, `GetCredentialByIdAsync`). Writes are untouched and keep the caller's spelling, matching the file backend, whose stored `ProviderName` is likewise verbatim.

## One difference documented rather than fixed

If a store holds two spellings of one provider, the file backend lists both and the native backends resolve to one. Reaching that state requires deliberately adding a provider twice under different casing — the normal path cannot, since the name comes from a single `ICredential.ProviderName` constant. It is called out in the interface remarks rather than papered over.

## Verification

Build clean, **380 tests** (330 passed, 50 skipped), up from 374.

The theory runs on **libsecret**, the one native backend exercisable on this machine. Removing the resolver from `ListCredentialsAsync` fails exactly the two non-canonical spellings while `Adobe` still passes — the divergence, reproduced:

```
failed ... ProviderLookups_AreCaseInsensitive(spelling: "adobe")
failed ... ProviderLookups_AreCaseInsensitive(spelling: "ADOBE")
```

The Keychain half is the same shape of change but is verified only by CI's macOS leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
