### PR TITLE
fix: create temp files with their final permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`accounts export` wrote the whole archive at default permissions before tightening them**
+  (#54). `AtomicFile` created its temp file with the umask default and chmod'd to `0600` only
+  after the entire payload had landed. For credential files and the keystore that is shielded
+  by the credentials directory's own `0700`, but `accounts export` writes to a destination the
+  user chooses — exporting to `/tmp` or any shared directory left every secret in the store
+  readable for the duration of the write. Temp files are now created with their final mode via
+  `FileStreamOptions.UnixCreateMode`, so the window does not exist.
+
 - **An imported archive dictated its own PBKDF2 iteration count, unbounded** (#53). The value
   came from the archive's clear-text envelope with only a `> 0` check and fed straight into
   `Rfc2898DeriveBytes.Pbkdf2`. `Iterations` is an `int`, so a hostile or corrupt archive could

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
@@ -33,14 +33,45 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             var tempPath = BuildTempPath(path);
             try
             {
-                await File.WriteAllTextAsync(tempPath, contents).ConfigureAwait(false);
-                ApplyUnixModeIfRequested(tempPath, unixMode);
+                await WriteTempAsync(tempPath, System.Text.Encoding.UTF8.GetBytes(contents), unixMode).ConfigureAwait(false);
                 await ReplaceAtomicallyAsync(tempPath, path).ConfigureAwait(false);
             }
             catch
             {
                 TryDelete(tempPath);
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Writes the temp file with its final permissions already in place.
+        /// </summary>
+        /// <remarks>
+        /// The mode is applied by <see cref="FileStreamOptions.UnixCreateMode"/> at creation
+        /// rather than chmod'd afterwards. Writing first and fixing permissions second left
+        /// the whole payload readable at the umask default for the duration of the write.
+        /// Inside the credentials directory that is shielded by its own <c>0700</c>, but
+        /// <c>accounts export</c> writes to a path the user chooses — exporting to <c>/tmp</c>
+        /// or any shared directory exposed every secret in the store for that window (#54).
+        /// </remarks>
+        private static async Task WriteTempAsync(string tempPath, byte[] bytes, UnixFileMode? unixMode)
+        {
+            var options = new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+            };
+
+            if (unixMode is not null && !OperatingSystem.IsWindows())
+            {
+                options.UnixCreateMode = unixMode.Value;
+            }
+
+            var stream = new FileStream(tempPath, options);
+            await using (stream.ConfigureAwait(false))
+            {
+                await stream.WriteAsync(bytes).ConfigureAwait(false);
             }
         }
 
@@ -71,8 +102,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             var tempPath = BuildTempPath(path);
             try
             {
-                await File.WriteAllBytesAsync(tempPath, bytes).ConfigureAwait(false);
-                ApplyUnixModeIfRequested(tempPath, unixMode);
+                await WriteTempAsync(tempPath, bytes, unixMode).ConfigureAwait(false);
 
                 // Deliberately not overwrite:true. A racing creator that already landed
                 // its keystore must win; we then fall back to reading theirs.
@@ -97,8 +127,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             var tempPath = BuildTempPath(path);
             try
             {
-                await File.WriteAllBytesAsync(tempPath, bytes).ConfigureAwait(false);
-                ApplyUnixModeIfRequested(tempPath, unixMode);
+                await WriteTempAsync(tempPath, bytes, unixMode).ConfigureAwait(false);
                 await ReplaceAtomicallyAsync(tempPath, path).ConfigureAwait(false);
             }
             catch
@@ -156,16 +185,6 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         // Unique per call to avoid collisions between concurrent writers, who
         // would otherwise both want the same `{path}.tmp` name.
         private static string BuildTempPath(string finalPath) => $"{finalPath}.{Guid.NewGuid():N}.tmp";
-
-        private static void ApplyUnixModeIfRequested(string path, UnixFileMode? unixMode)
-        {
-            if (unixMode is null || OperatingSystem.IsWindows())
-            {
-                return;
-            }
-
-            File.SetUnixFileMode(path, unixMode.Value);
-        }
 
         private static void TryDelete(string path)
         {

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/AtomicFileTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/AtomicFileTests.cs
@@ -128,5 +128,54 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             var files = Directory.GetFiles(temp.Path);
             Assert.Single(files);
         }
+
+        [Fact]
+        public async Task WriteAllTextAsync_TempFileIsNeverWorldReadable_WhileBeingWritten()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return; // Unix permissions only; Windows inherits the directory ACL.
+            }
+
+            using var temp = new TempDir();
+            var target = Path.Join(temp.Path, "export.bundle");
+
+            // A large payload makes the write window wide enough to observe. Before the fix
+            // the file was created at the umask default and chmod'd only after the whole
+            // payload had landed, so every secret sat readable at the temp path meanwhile
+            // (#54) -- which matters because `accounts export` writes to a user-chosen path
+            // that may not be inside the 0700 credentials directory.
+            var payload = new string('x', 4 * 1024 * 1024);
+
+            var write = AtomicFile.WriteAllTextAsync(
+                target, payload, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+
+            var offending = new List<string>();
+            while (!write.IsCompleted)
+            {
+                foreach (var f in Directory.GetFiles(temp.Path, "*.tmp"))
+                {
+                    try
+                    {
+                        var mode = File.GetUnixFileMode(f);
+                        if ((mode & (UnixFileMode.GroupRead | UnixFileMode.OtherRead)) != 0)
+                        {
+                            offending.Add($"{Path.GetFileName(f)} = {mode}");
+                        }
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        // Renamed out from under us; that is the success path.
+                    }
+                }
+            }
+
+            await write;
+
+            Assert.Empty(offending);
+            Assert.Equal(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                File.GetUnixFileMode(target));
+        }
     }
 }


### PR DESCRIPTION
Fixes #54.

## What changed

All three `AtomicFile` writers go through one helper that applies the Unix mode via `FileStreamOptions.UnixCreateMode` **at creation**, instead of chmod'ing after the payload is on disk.

## Why

```csharp
await File.WriteAllTextAsync(tempPath, contents);   // created at umask default, e.g. 0644
ApplyUnixModeIfRequested(tempPath, unixMode);       // tightened only now
```

## Scope — narrower than it first reads

For credential files and the keystore this was **not** exploitable: the temp path is inside the credentials directory, which `CredentialsDirectory.Ensure` creates `0700`, so no other user can traverse to it.

The real case is `accounts export`, which passes a **user-chosen** destination. Exporting to `/tmp` or any shared directory left the complete archive — every secret in the store, protected only by the passphrase — readable until the chmod landed.

I've kept that distinction in the code comment rather than describing it as a blanket world-readable window, because overstating it would make the comment wrong.

## Verification

Build clean, **396 tests** (346 passed, 50 skipped), up from 394.

The test writes a 4 MB payload and polls the temp file's mode for the duration of the write, asserting no group- or other-read bit is ever observed. Against the previous ordering it fails:

```
failed ... AtomicFileTests.WriteAllTextAsync_TempFileIsNeverWorldReadable_WhileBeingWritten
```

That red-proof matters here more than usual: a smaller payload would let the write finish before the first poll, and the test would pass vacuously against the broken code.

`ApplyUnixModeIfRequested` is deleted rather than left unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
