### PR TITLE
fix: release GList item references on every path in SearchItems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **libsecret leaked `SecretRetrievable` references when its search loop threw** (#56). The
+  per-item `g_object_unref` was the last statement of the loop body, so a throw part-way
+  through — `ThrowIfGError` on a locked collection or a per-item D-Bus error — skipped the
+  current item and every remaining one, while the `finally` called only `g_list_free`, which
+  releases the node structure and not the references the nodes hold. The `finally` now uses
+  `g_list_free_full` with `g_object_unref` as the destroy function, the idiomatic GLib form
+  for this ownership shape, so the references are released on every path.
+
 - **`accounts export` wrote the whole archive at default permissions before tightening them**
   (#54). `AtomicFile` created its temp file with the umask default and chmod'd to `0600` only
   after the entire payload had landed. For credential files and the keystore that is shielded

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
@@ -680,15 +680,17 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                             Attributes = managedAttrs,
                             Secret = secret,
                         });
-
-                        // Each GList node owns a reference to its data; releasing
-                        // the data item itself is the caller's job.
-                        g_object_unref(retrievable);
                     }
                 }
                 finally
                 {
-                    g_list_free(listPtr);
+                    // g_list_free_full releases every node's data as well as the node
+                    // structure. The per-item g_object_unref used to sit at the end of the
+                    // loop body, so a throw part-way through — ThrowIfGError on a locked
+                    // collection or a per-item D-Bus error — skipped the current item and
+                    // every remaining one, while this finally freed only the node structure
+                    // and not the references the nodes held (#56).
+                    g_list_free_full(listPtr, GObjectUnrefFunc);
                 }
                 return results;
             }

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretInterop.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretInterop.cs
@@ -66,6 +66,23 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         [LibraryImport(Libglib)]
         internal static partial void g_list_free(IntPtr list);
 
+        /// <summary>
+        /// Frees a GList <b>and</b> each node's data, using <paramref name="freeFunc"/>.
+        /// </summary>
+        /// <remarks>
+        /// Preferred over <see cref="g_list_free"/> whenever the nodes own references,
+        /// because it releases them even when the caller's loop exited early on an
+        /// exception — the case that leaked SecretRetrievable references (#56).
+        /// </remarks>
+        [LibraryImport(Libglib)]
+        internal static partial void g_list_free_full(IntPtr list, IntPtr freeFunc);
+
+        /// <summary>
+        /// Address of <c>g_object_unref</c>, for use as a GDestroyNotify with
+        /// <see cref="g_list_free_full"/>.
+        /// </summary>
+        internal static IntPtr GObjectUnrefFunc => ResolveExport(Libgobject, "g_object_unref");
+
         // =========================
         // GLib — GError
         // =========================


### PR DESCRIPTION
Fixes #56.

## What changed

`SearchItems`' `finally` now uses `g_list_free_full(listPtr, g_object_unref)` instead of `g_list_free`, and the per-item unref at the end of the loop body is removed.

## Why

The per-item release was the **last statement** of the loop body:

```csharp
results.Add(new StoredItem { ... });
g_object_unref(retrievable);        // only reached if nothing above threw
```

`ThrowIfGError` on the secret retrieve — a locked collection, a per-item D-Bus error — propagates out of the loop, so the current `retrievable` and every remaining one were never unreffed. The `finally` called only `g_list_free`, which releases the node structure and **not** the references the nodes hold.

`g_list_free_full` is the idiomatic GLib form for this ownership shape and releases them however the loop exits.

## Interop addition

`LibsecretInterop` gains the `g_list_free_full` declaration and a `GObjectUnrefFunc` property resolving `g_object_unref`'s address through the existing cached `ResolveExport` path — the same mechanism `NewAttributes` already uses for `g_str_hash`/`g_free`. No new resolution machinery.

## Verification and its limit

Build clean, **396 tests** (346 passed, 50 skipped) — unchanged, since no test is added.

The leak-on-throw path cannot be forced through the static P/Invoke surface, so it is **not directly covered**, and I am not claiming otherwise. What the suite does rule out is the more dangerous failure mode for a change like this: a wrong `GDestroyNotify` double-freeing or corrupting the list. All ~25 libsecret tests go through `SearchItems` and pass against a real Secret Service on this machine, which they would not if the ownership transfer were wrong.

Impact is bounded in practice — these are short-lived CLI processes — but unbounded in a long-running host that holds the manager and retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
