### PR TITLE
test: assert selection clearing on the record, not on absence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`DeleteCredentialAsync_ClearsSelection` asserted a null that the credential's absence
+  produced anyway** (#50), on all three backends. `GetSelectedCredentialAsync` resolves the id
+  from the selection record and then reads the credential, which is gone — so it returned null
+  whether or not the selection had been cleared, and the test passed with the entire clearing
+  block deleted. The file and libsecret tests now assert on the selection **record** itself
+  (`selections.json`, and the keyring's selection item via interop), which fails against a
+  removed clearing block. All three also pin that an unrelated provider's selection survives
+  the delete, catching over-broad clearing. The Keychain assertion remains weaker by
+  necessity — reaching its selection item would need a Security.framework query from the test
+  — and says so in place rather than reading as equivalent coverage.
+
 - **libsecret leaked `SecretRetrievable` references when its search loop threw** (#56). The
   per-item `g_object_unref` was the last statement of the loop body, so a throw part-way
   through — `ThrowIfGError` on a locked collection or a per-item D-Bus error — skipped the

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using NextIteration.SpectreConsole.Auth.Commands;
 using NextIteration.SpectreConsole.Auth.Encryption;
 using NextIteration.SpectreConsole.Auth.Persistence;
@@ -294,9 +296,26 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             using var temp = new TempDir();
             var manager = CreateManager(temp.Path);
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
-            _ = await manager.SelectCredentialAsync(accountId);
+            var unrelated = await manager.AddCredentialAsync("Airtable", "main", "Production", "{}");
+            Assert.True(await manager.SelectCredentialAsync(accountId));
+            Assert.True(await manager.SelectCredentialAsync(unrelated));
 
             _ = await manager.DeleteCredentialAsync(accountId);
+
+            // Asserted on the selection record itself, not through
+            // GetSelectedCredentialAsync. That returns null once the credential file is
+            // gone whether or not the selection was cleared, so the previous assertion
+            // passed even with the whole clearing block deleted (#50). The record is the
+            // only thing that actually distinguishes the two.
+            var selectionFile = Path.Join(temp.Path, "selections.json");
+            var selections = JsonSerializer.Deserialize<Dictionary<string, string>>(
+                await File.ReadAllTextAsync(selectionFile, TestContext.Current.CancellationToken))!;
+
+            Assert.False(selections.ContainsKey("Adobe"));
+
+            // And the delete must not disturb an unrelated provider's selection.
+            Assert.True(selections.ContainsKey("Airtable"));
+            Assert.Equal(unrelated, selections["Airtable"]);
 
             Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
         }

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -290,9 +290,19 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
             _ = await manager.SelectCredentialAsync(accountId);
 
+            var unrelated = await manager.AddCredentialAsync("Airtable", "main", "Production", "{}");
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(unrelated)));
+
             _ = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
 
+            // Weaker than its file and libsecret counterparts by necessity: the selection
+            // is a separate keychain item and this assertion returns null once the
+            // credential is gone regardless of whether that item was cleared, so it cannot
+            // distinguish the two (#50). Asserting on the item itself would need a
+            // Security.framework query from the test. What the unrelated-provider check
+            // below does catch is over-broad clearing, which is the more likely defect.
             Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
+            Assert.Equal("{}", await manager.GetSelectedCredentialAsync("Airtable"));
         }
 
         [Fact]

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -358,9 +358,36 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
             _ = await manager.SelectCredentialAsync(accountId);
 
+            var unrelated = await manager.AddCredentialAsync("Airtable", "main", "Production", "{}");
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(unrelated)));
+
             _ = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
 
+            // GetSelectedCredentialAsync returns null once the credential is gone whether
+            // or not the selection was cleared, so it cannot distinguish the two (#50).
+            // The selection is its own keyring item, so assert on that directly.
+            var stale = LibsecretInterop.NewAttributes(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["nextIteration.sca.app"] = _appIdentifier,
+                ["nextIteration.sca.kind"] = "selection",
+                ["nextIteration.sca.provider"] = "Adobe",
+            });
+            try
+            {
+                var found = LibsecretInterop.secret_password_searchv_sync(
+                    IntPtr.Zero, stale, LibsecretInterop.SecretSearchAll, IntPtr.Zero, out var error);
+                Assert.Equal(IntPtr.Zero, error);
+                Assert.Equal(IntPtr.Zero, found);
+            }
+            finally
+            {
+                LibsecretInterop.g_hash_table_unref(stale);
+            }
+
             Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
+
+            // An unrelated provider's selection must survive the delete.
+            Assert.Equal("{}", await manager.GetSelectedCredentialAsync("Airtable"));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #50.

## Why the old test proved nothing

```csharp
_ = await manager.DeleteCredentialAsync(accountId);
Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
```

`GetSelectedCredentialAsync` resolves the id from the selection record and *then* reads the credential — which the delete just removed. So it returns null either way, and the test passed with the entire selection-clearing block deleted. Same weak assertion on all three backends.

## What it asserts now

| Backend | Assertion |
|---|---|
| File | reads `selections.json` and asserts the provider key is absent |
| libsecret | queries the selection keyring item directly through `LibsecretInterop` and asserts nothing matches |
| Keychain | unchanged in kind — see below |

All three additionally add a second provider, select it, and assert **its** selection survives the delete. That catches over-broad clearing and works through the public API everywhere.

## Red-proof

Removing the clearing block from `FileCredentialManager.DeleteCredentialAsync`:

```
failed ... FileCredentialManagerTests.DeleteCredentialAsync_ClearsSelection_IfItWasSelected
```

The old assertion passed against that same sabotage. That difference is the entire point of the change.

## The Keychain case, stated plainly

Its selection is a separate keychain item and reaching it from a test would need a Security.framework query. So that assertion is still unable to distinguish "cleared" from "credential gone", and I have left a comment in the test saying exactly that rather than letting it read as equivalent coverage. The unrelated-provider check does bite there, which is the more likely defect anyway.

## Verification

Build clean, **396 tests** (346 passed, 50 skipped) — count unchanged, strength is what changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
