### PR TITLE
test: cover replacing an existing selection on all three backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Replacing an existing selection was never tested on any backend** (#51). Every
+  `SelectCredentialAsync` call in the suite was either a first selection or a negative case,
+  and the only multi-select test used *different* providers — so `KeychainCredentialManager`'s
+  `WriteSelection` never reached its `SecItemUpdate` branch, and the equivalent replace paths
+  on libsecret and the file backend were equally unexercised. That is the path every
+  `accounts select` after the first takes, and swapping between a prod and a sandbox
+  credential is the headline use case in the README. All three backends now have a test that
+  selects a second credential for the same provider and asserts exactly one ends up selected,
+  with the right payload resolved.
+
 - **`DeleteCredentialAsync_ClearsSelection` asserted a null that the credential's absence
   produced anyway** (#50), on all three backends. `GetSelectedCredentialAsync` resolves the id
   from the selection record and then reads the credential, which is gone — so it returned null

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -812,6 +812,31 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.Equal("{}", await manager.GetSelectedCredentialAsync("Adobe"));
         }
 
+        [Fact]
+        public async Task SelectCredentialAsync_ReplacingAnExistingSelection_LeavesExactlyOneSelected()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+
+            var prod = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"PROD\"}");
+            var sandbox = await manager.AddCredentialAsync("Adobe", "sandbox", "Sandbox", "{\"k\":\"SANDBOX\"}");
+
+            Assert.True(await manager.SelectCredentialAsync(prod));
+            Assert.Equal("{\"k\":\"PROD\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+
+            // Switching between a prod and a sandbox credential is the headline use case in
+            // the README, and no test ever exercised the replace path -- only first
+            // selections and negative cases (#51).
+            Assert.True(await manager.SelectCredentialAsync(sandbox));
+            Assert.Equal("{\"k\":\"SANDBOX\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+
+            var listed = (await manager.ListCredentialsAsync("Adobe")).ToList();
+            Assert.Equal(2, listed.Count);
+            Assert.Single(listed, c => c.IsSelected);
+            Assert.True(listed.Single(c => c.AccountId == sandbox).IsSelected);
+            Assert.False(listed.Single(c => c.AccountId == prod).IsSelected);
+        }
+
         /// <summary>
         /// Minimal summary provider used only to verify that
         /// <see cref="FileCredentialManager.ListCredentialsAsync"/> routes

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -421,6 +421,33 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.True(credential.IsDecryptable);
         }
 
+        [Fact]
+        [SupportedOSPlatform("macos")]
+        public async Task SelectCredentialAsync_ReplacingAnExistingSelection_LeavesExactlyOneSelected()
+        {
+            Assert.SkipWhen(_skip, SkipReason);
+
+            var manager = NewManager();
+            var prod = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"PROD\"}");
+            var sandbox = await manager.AddCredentialAsync("Adobe", "sandbox", "Sandbox", "{\"k\":\"SANDBOX\"}");
+
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(prod)));
+            Assert.Equal("{\"k\":\"PROD\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+
+            // The second selection for the same provider takes the update-an-existing-record
+            // branch, which no test reached before (#51) -- on this backend that is the
+            // difference between writing a new item and updating the one already there.
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(sandbox)));
+            Assert.Equal("{\"k\":\"SANDBOX\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+
+            var listed = await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"),
+                r => r.Count() == 2 && r.Count(c => c.IsSelected) == 1);
+
+            Assert.True(listed.Single(c => c.AccountId == sandbox).IsSelected);
+            Assert.False(listed.Single(c => c.AccountId == prod).IsSelected);
+        }
+
         private sealed class FakeAdobeSummaryProvider : ICredentialSummaryProvider
         {
             public string ProviderName => "Adobe";

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -581,6 +581,33 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.False(await manager.DeleteCredentialAsync(id));
         }
 
+        [Fact]
+        [SupportedOSPlatform("linux")]
+        public async Task SelectCredentialAsync_ReplacingAnExistingSelection_LeavesExactlyOneSelected()
+        {
+            Assert.SkipWhen(_skip, SkipReason);
+
+            var manager = NewManager();
+            var prod = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"k\":\"PROD\"}");
+            var sandbox = await manager.AddCredentialAsync("Adobe", "sandbox", "Sandbox", "{\"k\":\"SANDBOX\"}");
+
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(prod)));
+            Assert.Equal("{\"k\":\"PROD\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+
+            // The second selection for the same provider takes the update-an-existing-record
+            // branch, which no test reached before (#51) -- on this backend that is the
+            // difference between writing a new item and updating the one already there.
+            Assert.True(await RetryHelper.UntilTrueAsync(() => manager.SelectCredentialAsync(sandbox)));
+            Assert.Equal("{\"k\":\"SANDBOX\"}", await manager.GetSelectedCredentialAsync("Adobe"));
+
+            var listed = await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"),
+                r => r.Count() == 2 && r.Count(c => c.IsSelected) == 1);
+
+            Assert.True(listed.Single(c => c.AccountId == sandbox).IsSelected);
+            Assert.False(listed.Single(c => c.AccountId == prod).IsSelected);
+        }
+
         private sealed class FakeAdobeSummaryProvider : ICredentialSummaryProvider
         {
             public string ProviderName => "Adobe";


### PR DESCRIPTION
Fixes #51.

## The gap

Every `SelectCredentialAsync` call in the suite was either a first selection or a negative case. The only multi-select test — `SelectCredentialAsync_ConcurrentDifferentProviders_BothPersist` — uses *different* providers.

So no test ever selected a second credential for the **same** provider, which is:

- the path every `accounts select` after the first takes;
- the README's headline use case (*"a quick `accounts select <id>` swaps which one your auth service resolves"*);
- concretely, `KeychainCredentialManager.WriteSelection`'s `SecItemUpdate` branch — only `SecItemAdd` had ever executed.

## What was added

One test per backend: add two credentials for a provider, select the first, select the second, then assert exactly one is selected, that it is the second, and that `GetSelectedCredentialAsync` resolves the second's payload.

The `Assert.Single(listed, c => c.IsSelected)` is the load-bearing assertion — an add-where-update-was-needed leaves *two* selection records, and checking only that the new one is selected would miss that.

## Red-proof

Making libsecret's `WriteSelection` add-only — precisely the defect shape this covers:

```
failed ... LibsecretCredentialManagerTests.SelectCredentialAsync_ReplacingAnExistingSelection_LeavesExactlyOneSelected
```

The suite passed against that same sabotage before this PR, because nothing selected twice.

## Verification

Build clean, **402 tests** (350 passed, 52 skipped), up from 396. The Keychain case is the one that motivated the issue and is verified by CI's macOS leg; libsecret and file run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
