### PR TITLE
test: retry on the asserted property, not just the count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`RestoreCredentialAsync_Preserves…` flaked on the OS-native backends** (#61). The test
+  retried until one credential was visible and then asserted `IsSelected`, which comes from a
+  *separate* store item written moments earlier — so the credential could become visible
+  before the selection did and the assertion ran against a half-visible store. Observed once
+  on the macOS runner. The retry predicate now covers the property being asserted.
+
 - **`SelectionsLock`'s sentinel cleanup and exhaustion path were untested** (#57). The suite
   covered acquire, contend and re-acquire, but never asserted that `FileOptions.DeleteOnClose`
   actually removes the sentinel — one test's comment claimed it without checking — so dropping

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -115,7 +115,14 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.True(await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(id)));
             await manager.RestoreCredentialAsync(exported);
 
-            var restored = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
+            // Retry on the property actually being asserted, not just the count. The
+            // selection is a separate store item written moments earlier by
+            // RestoreCredentialAsync, so the credential can become visible before the
+            // selection does — and the count-only predicate let the assertions run against
+            // a half-visible store, which is what flaked on the macOS runner (#61).
+            var restored = Assert.Single(await RetryHelper.UntilAsync(
+                () => manager.ExportCredentialsAsync(),
+                r => r.Count == 1 && r[0].IsSelected));
             Assert.Equal(id, restored.AccountId);
             Assert.True(restored.IsSelected);
             Assert.Equal("{\"apiKey\":\"secret\"}", await manager.GetSelectedCredentialAsync("Adobe"));

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -184,7 +184,14 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.True(await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(id)));
             await manager.RestoreCredentialAsync(exported);
 
-            var restored = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
+            // Retry on the property actually being asserted, not just the count. The
+            // selection is a separate store item written moments earlier by
+            // RestoreCredentialAsync, so the credential can become visible before the
+            // selection does — and the count-only predicate let the assertions run against
+            // a half-visible store, which is what flaked on the macOS runner (#61).
+            var restored = Assert.Single(await RetryHelper.UntilAsync(
+                () => manager.ExportCredentialsAsync(),
+                r => r.Count == 1 && r[0].IsSelected));
             Assert.Equal(id, restored.AccountId);
             Assert.Equal(exported.CreatedAt, restored.CreatedAt); // libsecret preserves it via attribute
             Assert.True(restored.IsSelected);


### PR DESCRIPTION
Fixes #61.

## Why it flaked

```csharp
var restored = Assert.Single(await RetryHelper.UntilAsync(() => manager.ExportCredentialsAsync(), r => r.Count == 1));
Assert.True(restored.IsSelected);          // <- not covered by the wait
```

`IsSelected` is read from a **separate store item** — the selection record — written moments earlier by `RestoreCredentialAsync`. The credential item can become visible before the selection item does, so a count-only predicate lets the assertions run against a half-visible store.

Observed on the macOS leg of PR #60's CI; the identical commit then passed on `main`, which is what confirmed timing rather than regression.

## Fix

The predicate now covers the property being asserted:

```csharp
r => r.Count == 1 && r[0].IsSelected
```

Applied to both native backends — libsecret has the same shape and the same exposure, it just hasn't been unlucky yet.

## Verification

Build clean, **408 tests** (354 passed, 54 skipped) — unchanged; this is a timing fix, not new coverage.

A flake fix can't be proven by a green run, so I'm not claiming it is. What's verifiable is the mechanism: the wait now covers every value the test asserts, so there is no window where the assertions can observe a partially-visible store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
