### PR TITLE
feat!: thread CancellationToken through ICredentialManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- **`ICredentialManager` members now take a `CancellationToken`** (#74). Every member gains a
+  trailing `CancellationToken cancellationToken = default`. Existing *callers* keep compiling —
+  the parameter is optional — but any external **implementation** of the interface must update
+  its signatures. The three built-in backends are updated. `ICredentialCollector` and
+  `ICredentialSummaryProvider` are untouched, so the provider packages are unaffected.
+
+  The libsecret backend now binds the token to a `GCancellable` for every call, so
+  cancellation reaches libsecret rather than stopping at the managed boundary. The Keychain
+  backend honours the token at entry; Security.framework's `SecItem*` API offers no
+  mid-call cancellation, and that is documented rather than faked.
+
+  **What this does not fix, verified rather than assumed:** it does not rescue the KWallet
+  wedge that prompted the issue. Against `ksecretd` the cancellation callback does fire, but
+  the call still never returns, because ksecretd emits the prompt's `Completed` signal with an
+  `ao` payload where libsecret expects `o` — libsecret's `secret_service_real_prompt_async`
+  GTask is then *"finalized without ever returning"* and its nested main loop never exits.
+  That is an upstream libsecret/KWallet incompatibility, and it is recorded in the backend's
+  remarks instead of being papered over.
+
+  This makes the next release **2.0.0**; the version bump itself is a separate release PR.
+
 ### Changed
 
 - **The libsecret backend is now documented as GNOME Keyring only** (#19). It was described

--- a/src/NextIteration.SpectreConsole.Auth/Commands/AddCredentialCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/AddCredentialCommand.cs
@@ -83,14 +83,14 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                     collector.ProviderName,
                     settings.AccountName,
                     environment,
-                    credentialData).ConfigureAwait(false);
+                    credentialData, cancellationToken).ConfigureAwait(false);
 
                 AnsiConsole.MarkupLine($"[green]Successfully added credential with ID: {accountId}[/]");
 
                 // Ask if user wants to select this credential as active
                 if (await AnsiConsole.ConfirmAsync("Do you want to set this as the active credential for this environment?", cancellationToken: cancellationToken).ConfigureAwait(false))
                 {
-                    _ = await _credentialManager.SelectCredentialAsync(accountId).ConfigureAwait(false);
+                    _ = await _credentialManager.SelectCredentialAsync(accountId, cancellationToken).ConfigureAwait(false);
                     AnsiConsole.MarkupLine("[green]Credential selected as active.[/]");
                 }
 

--- a/src/NextIteration.SpectreConsole.Auth/Commands/DeleteCredentialCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/DeleteCredentialCommand.cs
@@ -31,7 +31,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                 else
                 {
                     // Interactive selection
-                    var providers = await _credentialManager.GetProviderNamesAsync().ConfigureAwait(false);
+                    var providers = await _credentialManager.GetProviderNamesAsync(cancellationToken).ConfigureAwait(false);
                     if (!providers.Any())
                     {
                         AnsiConsole.MarkupLine("[yellow]No credentials found.[/]");
@@ -41,7 +41,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                     var allCredentials = new List<CredentialSummary>();
                     foreach (var provider in providers)
                     {
-                        var credentials = await _credentialManager.ListCredentialsAsync(provider).ConfigureAwait(false);
+                        var credentials = await _credentialManager.ListCredentialsAsync(provider, cancellationToken).ConfigureAwait(false);
                         allCredentials.AddRange(credentials);
                     }
 
@@ -70,7 +70,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                     return 0;
                 }
 
-                var success = await _credentialManager.DeleteCredentialAsync(accountId).ConfigureAwait(false);
+                var success = await _credentialManager.DeleteCredentialAsync(accountId, cancellationToken).ConfigureAwait(false);
 
                 if (success)
                 {

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ExportCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ExportCredentialsCommand.cs
@@ -38,7 +38,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                 }
 
                 var service = new CredentialPortabilityService(_credentialManager);
-                var result = await service.ExportAsync(passphrase).ConfigureAwait(false);
+                var result = await service.ExportAsync(passphrase, cancellationToken).ConfigureAwait(false);
 
                 if (result.Count == 0)
                 {

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ImportCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ImportCredentialsCommand.cs
@@ -47,7 +47,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                 var resolver = BuildConflictResolver(settings.OnConflict, forcedResolution);
 
                 var service = new CredentialPortabilityService(_credentialManager);
-                var result = await service.ImportAsync(bundle, passphrase, resolver).ConfigureAwait(false);
+                var result = await service.ImportAsync(bundle, passphrase, resolver, cancellationToken).ConfigureAwait(false);
 
                 AnsiConsole.MarkupLine(
                     $"[green]Import complete:[/] {result.Added} added, {result.Overwritten} overwritten, {result.Skipped} skipped.");

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ListCredentialsCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ListCredentialsCommand.cs
@@ -40,7 +40,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
             {
                 if (string.IsNullOrWhiteSpace(settings.Provider))
                 {
-                    var providers = await _credentialManager.GetProviderNamesAsync().ConfigureAwait(false);
+                    var providers = await _credentialManager.GetProviderNamesAsync(cancellationToken).ConfigureAwait(false);
 
                     if (!providers.Any())
                     {
@@ -50,13 +50,13 @@ namespace NextIteration.SpectreConsole.Auth.Commands
 
                     foreach (var provider in providers)
                     {
-                        await DisplayCredentialsForProvider(provider).ConfigureAwait(false);
+                        await DisplayCredentialsForProvider(provider, cancellationToken).ConfigureAwait(false);
                         AnsiConsole.WriteLine();
                     }
                 }
                 else
                 {
-                    await DisplayCredentialsForProvider(settings.Provider).ConfigureAwait(false);
+                    await DisplayCredentialsForProvider(settings.Provider, cancellationToken).ConfigureAwait(false);
                 }
 
                 return 0;
@@ -69,9 +69,9 @@ namespace NextIteration.SpectreConsole.Auth.Commands
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "<Pending>")]
-        private async Task DisplayCredentialsForProvider(string provider)
+        private async Task DisplayCredentialsForProvider(string provider, CancellationToken cancellationToken)
         {
-            var credentials = (await _credentialManager.ListCredentialsAsync(provider).ConfigureAwait(false)).ToList();
+            var credentials = (await _credentialManager.ListCredentialsAsync(provider, cancellationToken).ConfigureAwait(false)).ToList();
 
             if (credentials.Count == 0)
             {

--- a/src/NextIteration.SpectreConsole.Auth/Commands/SelectCredentialCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/SelectCredentialCommand.cs
@@ -32,7 +32,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                 else
                 {
                     // Interactive selection
-                    var providers = await _credentialManager.GetProviderNamesAsync().ConfigureAwait(false);
+                    var providers = await _credentialManager.GetProviderNamesAsync(cancellationToken).ConfigureAwait(false);
                     if (!providers.Any())
                     {
                         AnsiConsole.MarkupLine("[yellow]No credentials found.[/]");
@@ -42,7 +42,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                     var allCredentials = new List<CredentialSummary>();
                     foreach (var provider in providers)
                     {
-                        var credentials = await _credentialManager.ListCredentialsAsync(provider).ConfigureAwait(false);
+                        var credentials = await _credentialManager.ListCredentialsAsync(provider, cancellationToken).ConfigureAwait(false);
                         allCredentials.AddRange(credentials);
                     }
 
@@ -63,7 +63,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                     accountId = allCredentials[selectedIndex].AccountId;
                 }
 
-                var success = await _credentialManager.SelectCredentialAsync(accountId).ConfigureAwait(false);
+                var success = await _credentialManager.SelectCredentialAsync(accountId, cancellationToken).ConfigureAwait(false);
 
                 if (success)
                 {

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
@@ -28,12 +28,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
     /// </remarks>
     internal static class AtomicFile
     {
-        internal static async Task WriteAllTextAsync(string path, string contents, UnixFileMode? unixMode = null)
+        internal static async Task WriteAllTextAsync(string path, string contents, UnixFileMode? unixMode = null, CancellationToken cancellationToken = default)
         {
             var tempPath = BuildTempPath(path);
             try
             {
-                await WriteTempAsync(tempPath, System.Text.Encoding.UTF8.GetBytes(contents), unixMode).ConfigureAwait(false);
+                await WriteTempAsync(tempPath, System.Text.Encoding.UTF8.GetBytes(contents), unixMode, cancellationToken).ConfigureAwait(false);
                 await ReplaceAtomicallyAsync(tempPath, path).ConfigureAwait(false);
             }
             catch
@@ -54,7 +54,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// <c>accounts export</c> writes to a path the user chooses — exporting to <c>/tmp</c>
         /// or any shared directory exposed every secret in the store for that window (#54).
         /// </remarks>
-        private static async Task WriteTempAsync(string tempPath, byte[] bytes, UnixFileMode? unixMode)
+        private static async Task WriteTempAsync(string tempPath, byte[] bytes, UnixFileMode? unixMode, CancellationToken cancellationToken)
         {
             var options = new FileStreamOptions
             {
@@ -71,7 +71,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             var stream = new FileStream(tempPath, options);
             await using (stream.ConfigureAwait(false))
             {
-                await stream.WriteAsync(bytes).ConfigureAwait(false);
+                await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -92,7 +92,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// the winner. Used for the keystore, where an overwrite silently destroys every
         /// credential already encrypted under the replaced key.
         /// </remarks>
-        internal static async Task<bool> TryWriteNewAsync(string path, byte[] bytes, UnixFileMode? unixMode = null)
+        internal static async Task<bool> TryWriteNewAsync(string path, byte[] bytes, UnixFileMode? unixMode = null, CancellationToken cancellationToken = default)
         {
             if (File.Exists(path))
             {
@@ -102,7 +102,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             var tempPath = BuildTempPath(path);
             try
             {
-                await WriteTempAsync(tempPath, bytes, unixMode).ConfigureAwait(false);
+                await WriteTempAsync(tempPath, bytes, unixMode, cancellationToken).ConfigureAwait(false);
 
                 // Deliberately not overwrite:true. A racing creator that already landed
                 // its keystore must win; we then fall back to reading theirs.
@@ -122,12 +122,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             }
         }
 
-        internal static async Task WriteAllBytesAsync(string path, byte[] bytes, UnixFileMode? unixMode = null)
+        internal static async Task WriteAllBytesAsync(string path, byte[] bytes, UnixFileMode? unixMode = null, CancellationToken cancellationToken = default)
         {
             var tempPath = BuildTempPath(path);
             try
             {
-                await WriteTempAsync(tempPath, bytes, unixMode).ConfigureAwait(false);
+                await WriteTempAsync(tempPath, bytes, unixMode, cancellationToken).ConfigureAwait(false);
                 await ReplaceAtomicallyAsync(tempPath, path).ConfigureAwait(false);
             }
             catch

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/FileCredentialManager.cs
@@ -50,7 +50,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName)
+        public async Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
 
@@ -61,7 +61,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             var credentialFiles = Directory.GetFiles(_credentialsDirectory, $"{providerPrefix}_*.json");
 
             var credentials = new List<CredentialSummary>();
-            var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+            var selections = await LoadSelectionsAsync(cancellationToken).ConfigureAwait(false);
             _ = _summaryProviders.TryGetValue(providerName, out var summaryProvider);
 
             foreach (var file in credentialFiles)
@@ -69,7 +69,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                 StoredCredential? credential;
                 try
                 {
-                    var content = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+                    var content = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
                     credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
                 }
                 catch (JsonException)
@@ -138,7 +138,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         }
 
         /// <inheritdoc />
-        public async Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData)
+        public async Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
 
@@ -168,20 +168,21 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             await AtomicFile.WriteAllTextAsync(
                 filePath,
                 json,
-                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);
+                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                cancellationToken).ConfigureAwait(false);
 
             return accountId;
         }
 
         /// <inheritdoc />
-        public async Task<bool> DeleteCredentialAsync(string accountId)
+        public async Task<bool> DeleteCredentialAsync(string accountId, CancellationToken cancellationToken = default)
         {
             if (!IsValidAccountId(accountId))
             {
                 return false;
             }
 
-            var found = await FindCredentialByAccountIdAsync(accountId).ConfigureAwait(false);
+            var found = await FindCredentialByAccountIdAsync(accountId, cancellationToken).ConfigureAwait(false);
             if (found is null)
             {
                 return false;
@@ -192,46 +193,46 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
 
             // Hold the selections lock across load+modify+save so a concurrent
             // select/delete on a different provider can't lose its update.
-            using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile).ConfigureAwait(false);
-            var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+            using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile, cancellationToken).ConfigureAwait(false);
+            var selections = await LoadSelectionsAsync(cancellationToken).ConfigureAwait(false);
             if (selections.TryGetValue(credential.ProviderName, out var selectedId) &&
                 selectedId.Equals(accountId, StringComparison.OrdinalIgnoreCase))
             {
                 _ = selections.Remove(credential.ProviderName);
-                await SaveSelectionsAsync(selections).ConfigureAwait(false);
+                await SaveSelectionsAsync(selections, cancellationToken).ConfigureAwait(false);
             }
 
             return true;
         }
 
         /// <inheritdoc />
-        public async Task<bool> SelectCredentialAsync(string accountId)
+        public async Task<bool> SelectCredentialAsync(string accountId, CancellationToken cancellationToken = default)
         {
             if (!IsValidAccountId(accountId))
             {
                 return false;
             }
 
-            var found = await FindCredentialByAccountIdAsync(accountId).ConfigureAwait(false);
+            var found = await FindCredentialByAccountIdAsync(accountId, cancellationToken).ConfigureAwait(false);
             if (found is null)
             {
                 return false;
             }
 
             var credential = found.Value.Credential;
-            using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile).ConfigureAwait(false);
-            var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+            using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile, cancellationToken).ConfigureAwait(false);
+            var selections = await LoadSelectionsAsync(cancellationToken).ConfigureAwait(false);
             selections[credential.ProviderName] = accountId;
-            await SaveSelectionsAsync(selections).ConfigureAwait(false);
+            await SaveSelectionsAsync(selections, cancellationToken).ConfigureAwait(false);
             return true;
         }
 
         /// <inheritdoc />
-        public async Task<string?> GetSelectedCredentialAsync(string providerName)
+        public async Task<string?> GetSelectedCredentialAsync(string providerName, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
 
-            var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+            var selections = await LoadSelectionsAsync(cancellationToken).ConfigureAwait(false);
             if (!selections.TryGetValue(providerName, out var selectedId) || !IsValidAccountId(selectedId))
             {
                 // A non-GUID id can only land here via tampered selections.json;
@@ -240,16 +241,16 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                 return null;
             }
 
-            return await ReadAndDecryptByIdAsync(providerName, selectedId).ConfigureAwait(false);
+            return await ReadAndDecryptByIdAsync(providerName, selectedId, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task<string?> GetCredentialByIdAsync(string providerName, string accountId)
+        public async Task<string?> GetCredentialByIdAsync(string providerName, string accountId, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
             ValidateAccountId(accountId);
 
-            return await ReadAndDecryptByIdAsync(providerName, accountId).ConfigureAwait(false);
+            return await ReadAndDecryptByIdAsync(providerName, accountId, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -261,7 +262,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// the account id from <c>selections.json</c>) and
         /// <see cref="GetCredentialByIdAsync"/> (which takes it directly).
         /// </summary>
-        private async Task<string?> ReadAndDecryptByIdAsync(string providerName, string accountId)
+        private async Task<string?> ReadAndDecryptByIdAsync(string providerName, string accountId, CancellationToken cancellationToken)
         {
             var fileName = $"{providerName.ToLowerInvariant()}_{accountId}.json";
             var filePath = Path.Join(_credentialsDirectory, fileName);
@@ -273,7 +274,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             StoredCredential? credential;
             try
             {
-                var content = await File.ReadAllTextAsync(filePath).ConfigureAwait(false);
+                var content = await File.ReadAllTextAsync(filePath, cancellationToken).ConfigureAwait(false);
                 credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
             }
             catch (JsonException)
@@ -289,14 +290,14 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// credentials directory for <c>*_{accountId}.json</c>. AccountIds are
         /// GUIDs so the pattern is expected to match at most one file.
         /// </summary>
-        private async Task<(string FilePath, StoredCredential Credential)?> FindCredentialByAccountIdAsync(string accountId)
+        private async Task<(string FilePath, StoredCredential Credential)?> FindCredentialByAccountIdAsync(string accountId, CancellationToken cancellationToken)
         {
             var matches = Directory.GetFiles(_credentialsDirectory, $"*_{accountId}.json");
             foreach (var file in matches)
             {
                 try
                 {
-                    var content = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+                    var content = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
                     var credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
                     if (credential is not null &&
                         credential.AccountId.Equals(accountId, StringComparison.OrdinalIgnoreCase))
@@ -314,7 +315,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         }
 
         /// <inheritdoc />
-        public async Task<IEnumerable<string>> GetProviderNamesAsync()
+        public async Task<IEnumerable<string>> GetProviderNamesAsync(CancellationToken cancellationToken = default)
         {
             var credentialFiles = Directory.GetFiles(_credentialsDirectory, "*.json")
                 .Where(f => !f.Equals(_selectionFile, StringComparison.OrdinalIgnoreCase));
@@ -325,7 +326,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             {
                 try
                 {
-                    var content = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+                    var content = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
                     var credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
 
                     if (!string.IsNullOrWhiteSpace(credential?.ProviderName))
@@ -343,14 +344,14 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         }
 
         /// <inheritdoc />
-        public async Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync()
+        public async Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync(CancellationToken cancellationToken = default)
         {
             // Every *.json in the directory except the selection record is a
             // stored credential; mirrors the glob GetProviderNamesAsync uses.
             var credentialFiles = Directory.GetFiles(_credentialsDirectory, "*.json")
                 .Where(f => !f.Equals(_selectionFile, StringComparison.OrdinalIgnoreCase));
 
-            var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+            var selections = await LoadSelectionsAsync(cancellationToken).ConfigureAwait(false);
             var exports = new List<CredentialExport>();
 
             foreach (var file in credentialFiles)
@@ -358,7 +359,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                 StoredCredential? credential;
                 try
                 {
-                    var content = await File.ReadAllTextAsync(file).ConfigureAwait(false);
+                    var content = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
                     credential = JsonSerializer.Deserialize<StoredCredential>(content, _jsonOptions);
                 }
                 catch (JsonException)
@@ -409,7 +410,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         }
 
         /// <inheritdoc />
-        public async Task RestoreCredentialAsync(CredentialExport credential)
+        public async Task RestoreCredentialAsync(CredentialExport credential, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(credential);
 
@@ -441,14 +442,15 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             await AtomicFile.WriteAllTextAsync(
                 filePath,
                 json,
-                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);
+                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                cancellationToken).ConfigureAwait(false);
 
             if (credential.IsSelected)
             {
-                using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile).ConfigureAwait(false);
-                var selections = await LoadSelectionsAsync().ConfigureAwait(false);
+                using var selectionsLock = await SelectionsLock.AcquireAsync(_selectionLockFile, cancellationToken).ConfigureAwait(false);
+                var selections = await LoadSelectionsAsync(cancellationToken).ConfigureAwait(false);
                 selections[credential.ProviderName] = credential.AccountId;
-                await SaveSelectionsAsync(selections).ConfigureAwait(false);
+                await SaveSelectionsAsync(selections, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -509,7 +511,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// selected. A green tick in `accounts list` alongside "no credential selected"
         /// from the consumer's authenticate call (#48).
         /// </remarks>
-        private async Task<Dictionary<string, string>> LoadSelectionsAsync()
+        private async Task<Dictionary<string, string>> LoadSelectionsAsync(CancellationToken cancellationToken)
         {
             if (!File.Exists(_selectionFile))
             {
@@ -519,7 +521,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             Dictionary<string, string>? loaded;
             try
             {
-                var content = await File.ReadAllTextAsync(_selectionFile).ConfigureAwait(false);
+                var content = await File.ReadAllTextAsync(_selectionFile, cancellationToken).ConfigureAwait(false);
                 loaded = JsonSerializer.Deserialize<Dictionary<string, string>>(content, _jsonOptions);
             }
             catch (JsonException)
@@ -544,7 +546,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             return selections;
         }
 
-        private async Task SaveSelectionsAsync(Dictionary<string, string> selections)
+        private async Task SaveSelectionsAsync(Dictionary<string, string> selections, CancellationToken cancellationToken)
         {
             var json = JsonSerializer.Serialize(selections, _jsonOptions);
 
@@ -555,7 +557,8 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
             await AtomicFile.WriteAllTextAsync(
                 _selectionFile,
                 json,
-                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite).ConfigureAwait(false);
+                OperatingSystem.IsWindows() ? null : UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class StoredCredential

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/ICredentialManager.cs
@@ -9,6 +9,19 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
     /// </summary>
     /// <remarks>
     /// <para>
+    /// <b>Every member accepts a <see cref="CancellationToken"/>.</b> Implementations backed
+    /// by an OS secret store must honour it: the Secret Service contract permits an
+    /// implementation to prompt (to unlock a collection, say) before serving a request, and a
+    /// synchronous call that cannot be cancelled then blocks with no way out (#74).
+    /// </para>
+    /// <para>
+    /// Honouring the token is not a guarantee that every block is escapable. The libsecret
+    /// backend wires the token to a <c>GCancellable</c>, which libsecret observes for its own
+    /// D-Bus work — but a Secret Service implementation that breaks libsecret's prompt
+    /// machinery can still wedge it beyond the reach of cancellation. See the remarks on
+    /// <c>LibsecretCredentialManager</c> for a case where exactly that happens.
+    /// </para>
+    /// <para>
     /// <b>Provider names are matched case-insensitively</b> and stored as supplied.
     /// A credential added as <c>Adobe</c> is found by a lookup for <c>adobe</c>, and
     /// the spelling the caller used is what <see cref="CredentialSummary.ProviderName"/>
@@ -32,7 +45,8 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// Lists all stored credentials for a specific provider.
         /// </summary>
         /// <param name="providerName">The provider (e.g. <c>Adobe</c>).</param>
-        Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName);
+        /// <param name="cancellationToken">Cancels the operation; see the interface remarks.</param>
+        Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stores a new credential and returns its generated account ID.
@@ -42,28 +56,29 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// <param name="environment">Environment the credential targets (e.g. <c>Production</c>).</param>
         /// <param name="credentialData">Plaintext JSON payload to encrypt and persist.</param>
         /// <returns>The account ID assigned to the new credential (a GUID).</returns>
-        Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData);
+        /// <param name="cancellationToken">Cancels the operation; see the interface remarks.</param>
+        Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a credential by its account ID, and clears any selection
         /// that pointed to it.
         /// </summary>
         /// <returns><see langword="true"/> if the credential existed and was deleted.</returns>
-        Task<bool> DeleteCredentialAsync(string accountId);
+        Task<bool> DeleteCredentialAsync(string accountId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Marks the credential as the active one for its provider. Exactly
         /// one credential per provider may be selected at a time.
         /// </summary>
         /// <returns><see langword="true"/> if the credential was found and selected.</returns>
-        Task<bool> SelectCredentialAsync(string accountId);
+        Task<bool> SelectCredentialAsync(string accountId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the decrypted JSON payload of the currently selected
         /// credential for <paramref name="providerName"/>, or
         /// <see langword="null"/> if no credential is selected.
         /// </summary>
-        Task<string?> GetSelectedCredentialAsync(string providerName);
+        Task<string?> GetSelectedCredentialAsync(string providerName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the decrypted JSON payload of a specific credential by
@@ -79,13 +94,14 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// The decrypted JSON payload, or <see langword="null"/> if no
         /// credential with that account id exists for the given provider.
         /// </returns>
-        Task<string?> GetCredentialByIdAsync(string providerName, string accountId);
+        /// <param name="cancellationToken">Cancels the operation; see the interface remarks.</param>
+        Task<string?> GetCredentialByIdAsync(string providerName, string accountId, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns the set of provider names that currently have at least
         /// one stored credential.
         /// </summary>
-        Task<IEnumerable<string>> GetProviderNamesAsync();
+        Task<IEnumerable<string>> GetProviderNamesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enumerates the stored credentials across all providers whose payload can
@@ -117,7 +133,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// <see cref="ListCredentialsAsync"/>, which reads metadata only.
         /// </para>
         /// </remarks>
-        Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync();
+        Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Recreates a credential from an export record, preserving its
@@ -139,7 +155,8 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
         /// restored item's <see cref="CredentialExport.CreatedAt"/> is not
         /// preserved there.
         /// </remarks>
-        Task RestoreCredentialAsync(CredentialExport credential);
+        /// <param name="cancellationToken">Cancels the operation; see the interface remarks.</param>
+        Task RestoreCredentialAsync(CredentialExport credential, CancellationToken cancellationToken = default);
     }
 
     /// <summary>

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Keychain/KeychainCredentialManager.cs
@@ -59,8 +59,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData)
+        public Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ValidateProviderName(providerName);
             var accountId = Guid.NewGuid().ToString();
 
@@ -110,8 +111,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName)
+        public Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ValidateProviderName(providerName);
             providerName = ResolveStoredProviderName(providerName);
             var service = ServiceFor(providerName);
@@ -146,8 +148,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<bool> DeleteCredentialAsync(string accountId)
+        public Task<bool> DeleteCredentialAsync(string accountId, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!IsValidAccountId(accountId))
             {
                 return Task.FromResult(false);
@@ -176,8 +179,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<bool> SelectCredentialAsync(string accountId)
+        public Task<bool> SelectCredentialAsync(string accountId, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!IsValidAccountId(accountId))
             {
                 return Task.FromResult(false);
@@ -200,8 +204,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<string?> GetSelectedCredentialAsync(string providerName)
+        public Task<string?> GetSelectedCredentialAsync(string providerName, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ValidateProviderName(providerName);
             providerName = ResolveStoredProviderName(providerName);
             var selectedId = ReadSelection(providerName);
@@ -214,8 +219,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<string?> GetCredentialByIdAsync(string providerName, string accountId)
+        public Task<string?> GetCredentialByIdAsync(string providerName, string accountId, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ValidateProviderName(providerName);
             providerName = ResolveStoredProviderName(providerName);
             ValidateAccountId(accountId);
@@ -244,8 +250,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<IEnumerable<string>> GetProviderNamesAsync()
+        public Task<IEnumerable<string>> GetProviderNamesAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             // Query every generic-password item owned by this app and distinct
             // the provider portion out of the service string.
             var items = QueryAllItemsForApp(includeData: false);
@@ -262,8 +269,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync()
+        public Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync(CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var items = QueryAllItemsForApp(includeData: true);
             var selectionCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
@@ -320,8 +328,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Keychain
         }
 
         /// <inheritdoc />
-        public Task RestoreCredentialAsync(CredentialExport credential)
+        public Task RestoreCredentialAsync(CredentialExport credential, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ArgumentNullException.ThrowIfNull(credential);
             ValidateProviderName(credential.ProviderName);
             ValidateAccountId(credential.AccountId);

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
@@ -21,10 +21,20 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
     /// tested and fails unattended in two ways (#19): it does not provide the
     /// <c>session</c> collection GNOME Keyring offers, so selecting it fails with
     /// <c>No such object path '/org/freedesktop/secrets/aliases/session'</c>; and against
-    /// the default collection it raises a wallet-unlock prompt, which with no GUI blocks
-    /// the calling thread forever because the synchronous libsecret entry points here are
-    /// invoked with a NULL <c>GCancellable</c>. Other Secret Service implementations are
-    /// untested.
+    /// the default collection it raises a wallet-unlock prompt which, with no GUI, never
+    /// completes.
+    /// </para>
+    /// <para>
+    /// That second failure is <b>not</b> reachable by cancellation, and is worth recording
+    /// precisely. ksecretd emits the prompt's <c>Completed</c> signal with an <c>ao</c>
+    /// payload where libsecret expects <c>o</c>, so libsecret logs
+    /// <c>received unexpected result type ao from Completed signal</c> and its
+    /// <c>secret_service_real_prompt_async</c> GTask is then
+    /// <c>finalized without ever returning</c>. The nested main loop the synchronous wrapper
+    /// runs therefore never exits. Cancelling the <c>GCancellable</c> does fire — verified —
+    /// but cannot rescue a task libsecret has already abandoned. It is an upstream
+    /// incompatibility between libsecret and KWallet's shim, not something this backend can
+    /// work around.
     /// </para>
     /// <para>
     /// Requires a running Secret Service daemon. Headless containers and
@@ -81,7 +91,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData)
+        public Task<string> AddCredentialAsync(string providerName, string accountName, string environment, string credentialData, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
             var accountId = Guid.NewGuid().ToString();
@@ -98,13 +108,13 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             };
             var label = $"{_appIdentifier}: {providerName}/{accountName}";
 
-            StoreItem(attrs, label, credentialData);
+            StoreItem(cancellationToken, attrs, label, credentialData);
 
             // A just-stored Secret Service item isn't always immediately visible
             // to a follow-up search under concurrent access, so a caller doing
             // add-then-select/delete can race the item's appearance. Confirm it's
             // queryable before returning so that can't happen.
-            ConfirmItemVisible(providerName, accountId);
+            ConfirmItemVisible(providerName, accountId, cancellationToken);
 
             return Task.FromResult(accountId);
         }
@@ -115,12 +125,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         /// returns after a bounded wait even if the item never appears, leaving
         /// any genuine failure to the caller's own lookup.
         /// </summary>
-        private void ConfirmItemVisible(string providerName, string accountId)
+        private void ConfirmItemVisible(string providerName, string accountId, CancellationToken cancellationToken)
         {
             const int maxAttempts = 20;
             for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                if (LookupCredentialByAccountId(providerName, accountId) is not null)
+                if (LookupCredentialByAccountId(providerName, accountId, cancellationToken) is not null)
                 {
                     return;
                 }
@@ -133,13 +143,13 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName)
+        public Task<IEnumerable<CredentialSummary>> ListCredentialsAsync(string providerName, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
-            providerName = ResolveStoredProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName, cancellationToken);
             _summaryProviders.TryGetValue(providerName, out var summaryProvider);
 
-            var selectedId = ReadSelection(providerName);
+            var selectedId = ReadSelection(providerName, cancellationToken);
             var items = SearchItems(
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
@@ -147,7 +157,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                     [AttrKind] = KindCredential,
                     [AttrProvider] = providerName,
                 },
-                loadSecrets: summaryProvider is not null);
+                loadSecrets: summaryProvider is not null, cancellationToken);
 
             var result = items
                 .Select(i => new CredentialSummary
@@ -176,7 +186,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task<bool> DeleteCredentialAsync(string accountId)
+        public Task<bool> DeleteCredentialAsync(string accountId, CancellationToken cancellationToken = default)
         {
             if (!IsValidAccountId(accountId))
             {
@@ -191,14 +201,14 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                     [AttrKind] = KindCredential,
                     [AttrAccount] = accountId,
                 },
-                loadSecrets: false).FirstOrDefault();
+                loadSecrets: false, cancellationToken).FirstOrDefault();
 
             if (match is null)
             {
                 return Task.FromResult(false);
             }
 
-            var removed = ClearItem(new Dictionary<string, string>(StringComparer.Ordinal)
+            var removed = ClearItem(cancellationToken, new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 [AttrApp] = _appIdentifier,
                 [AttrKind] = KindCredential,
@@ -219,10 +229,10 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             var providerName = match.Attributes.GetValueOrDefault(AttrProvider);
             if (providerName is not null)
             {
-                var selected = ReadSelection(providerName);
+                var selected = ReadSelection(providerName, cancellationToken);
                 if (string.Equals(selected, accountId, StringComparison.OrdinalIgnoreCase))
                 {
-                    ClearSelection(providerName);
+                    ClearSelection(providerName, cancellationToken);
                 }
             }
 
@@ -230,7 +240,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task<bool> SelectCredentialAsync(string accountId)
+        public Task<bool> SelectCredentialAsync(string accountId, CancellationToken cancellationToken = default)
         {
             if (!IsValidAccountId(accountId))
             {
@@ -244,7 +254,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                     [AttrKind] = KindCredential,
                     [AttrAccount] = accountId,
                 },
-                loadSecrets: false).FirstOrDefault();
+                loadSecrets: false, cancellationToken).FirstOrDefault();
 
             if (match is null)
             {
@@ -257,32 +267,32 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                 return Task.FromResult(false);
             }
 
-            WriteSelection(providerName, accountId);
+            WriteSelection(providerName, accountId, cancellationToken);
             return Task.FromResult(true);
         }
 
         /// <inheritdoc />
-        public Task<string?> GetSelectedCredentialAsync(string providerName)
+        public Task<string?> GetSelectedCredentialAsync(string providerName, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
-            providerName = ResolveStoredProviderName(providerName);
-            var selectedId = ReadSelection(providerName);
+            providerName = ResolveStoredProviderName(providerName, cancellationToken);
+            var selectedId = ReadSelection(providerName, cancellationToken);
             if (selectedId is null)
             {
                 return Task.FromResult<string?>(null);
             }
 
-            return Task.FromResult(LookupCredentialByAccountId(providerName, selectedId));
+            return Task.FromResult(LookupCredentialByAccountId(providerName, selectedId, cancellationToken));
         }
 
         /// <inheritdoc />
-        public Task<string?> GetCredentialByIdAsync(string providerName, string accountId)
+        public Task<string?> GetCredentialByIdAsync(string providerName, string accountId, CancellationToken cancellationToken = default)
         {
             ValidateProviderName(providerName);
-            providerName = ResolveStoredProviderName(providerName);
+            providerName = ResolveStoredProviderName(providerName, cancellationToken);
             ValidateAccountId(accountId);
 
-            return Task.FromResult(LookupCredentialByAccountId(providerName, accountId));
+            return Task.FromResult(LookupCredentialByAccountId(providerName, accountId, cancellationToken));
         }
 
         /// <summary>
@@ -291,9 +301,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         /// and <see cref="GetCredentialByIdAsync"/> — neither modifies the
         /// selection record.
         /// </summary>
-        private string? LookupCredentialByAccountId(string providerName, string accountId)
+        private string? LookupCredentialByAccountId(string providerName, string accountId, CancellationToken cancellationToken)
         {
-            return LookupPassword(new Dictionary<string, string>(StringComparer.Ordinal)
+            return LookupPassword(cancellationToken, new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 [AttrApp] = _appIdentifier,
                 [AttrKind] = KindCredential,
@@ -303,7 +313,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task<IEnumerable<string>> GetProviderNamesAsync()
+        public Task<IEnumerable<string>> GetProviderNamesAsync(CancellationToken cancellationToken = default)
         {
             var items = SearchItems(
                 new Dictionary<string, string>(StringComparer.Ordinal)
@@ -311,7 +321,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                     [AttrApp] = _appIdentifier,
                     [AttrKind] = KindCredential,
                 },
-                loadSecrets: false);
+                loadSecrets: false, cancellationToken);
 
             var names = items
                 .Select(i => i.Attributes.GetValueOrDefault(AttrProvider))
@@ -324,7 +334,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync()
+        public Task<IReadOnlyList<CredentialExport>> ExportCredentialsAsync(CancellationToken cancellationToken = default)
         {
             var items = SearchItems(
                 new Dictionary<string, string>(StringComparer.Ordinal)
@@ -332,7 +342,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                     [AttrApp] = _appIdentifier,
                     [AttrKind] = KindCredential,
                 },
-                loadSecrets: true);
+                loadSecrets: true, cancellationToken);
 
             var selectionCache = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
@@ -366,7 +376,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
 
                 if (!selectionCache.TryGetValue(providerName, out var selectedId))
                 {
-                    selectedId = ReadSelection(providerName);
+                    selectedId = ReadSelection(providerName, cancellationToken);
                     selectionCache[providerName] = selectedId;
                 }
 
@@ -388,7 +398,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         }
 
         /// <inheritdoc />
-        public Task RestoreCredentialAsync(CredentialExport credential)
+        public Task RestoreCredentialAsync(CredentialExport credential, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(credential);
             ValidateProviderName(credential.ProviderName);
@@ -410,11 +420,11 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             };
             var label = $"{_appIdentifier}: {credential.ProviderName}/{credential.AccountName}";
 
-            StoreItem(attrs, label, credential.CredentialData);
+            StoreItem(cancellationToken, attrs, label, credential.CredentialData);
 
             if (credential.IsSelected)
             {
-                WriteSelection(credential.ProviderName, credential.AccountId);
+                WriteSelection(credential.ProviderName, credential.AccountId, cancellationToken);
             }
 
             return Task.CompletedTask;
@@ -424,9 +434,9 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         // Internal helpers
         // =========================
 
-        private string? ReadSelection(string providerName)
+        private string? ReadSelection(string providerName, CancellationToken cancellationToken)
         {
-            return LookupPassword(new Dictionary<string, string>(StringComparer.Ordinal)
+            return LookupPassword(cancellationToken, new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 [AttrApp] = _appIdentifier,
                 [AttrKind] = KindSelection,
@@ -434,11 +444,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             });
         }
 
-        private void WriteSelection(string providerName, string accountId)
+        private void WriteSelection(string providerName, string accountId, CancellationToken cancellationToken)
         {
             // store overwrites an existing item with matching attributes, so
             // we don't need a separate add-or-update dance.
             StoreItem(
+                cancellationToken,
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     [AttrApp] = _appIdentifier,
@@ -449,12 +460,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                 password: accountId);
         }
 
-        private void ClearSelection(string providerName)
+        private void ClearSelection(string providerName, CancellationToken cancellationToken)
         {
             // Discard deliberately: clearing a selection that was never recorded is a
             // no-op, not a failure. Only DeleteCredentialAsync needs the result, because
             // there "nothing removed" means the credential is still stored.
-            _ = ClearItem(new Dictionary<string, string>(StringComparer.Ordinal)
+            _ = ClearItem(cancellationToken, new Dictionary<string, string>(StringComparer.Ordinal)
             {
                 [AttrApp] = _appIdentifier,
                 [AttrKind] = KindSelection,
@@ -490,7 +501,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         /// the stored spelling is used for the query. Falls back to the caller's spelling
         /// when nothing matches, so a genuine miss still behaves as a miss (#49).
         /// </remarks>
-        private string ResolveStoredProviderName(string providerName)
+        private string ResolveStoredProviderName(string providerName, CancellationToken cancellationToken)
         {
             var items = SearchItems(
                 new Dictionary<string, string>(StringComparer.Ordinal)
@@ -498,7 +509,7 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                     [AttrApp] = _appIdentifier,
                     [AttrKind] = KindCredential,
                 },
-                loadSecrets: false);
+                loadSecrets: false, cancellationToken);
 
             foreach (var item in items)
             {
@@ -511,6 +522,69 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             }
 
             return providerName;
+        }
+
+        /// <summary>
+        /// Binds a <see cref="CancellationToken"/> to a GCancellable for the lifetime of one
+        /// libsecret call, so a blocked synchronous call can actually be made to return.
+        /// </summary>
+        /// <remarks>
+        /// The Secret Service contract lets an implementation prompt — to unlock a collection,
+        /// say — before serving a request, and the synchronous entry points here block until
+        /// that prompt is answered. With no GUI nothing answers it. Passing NULL for the
+        /// cancellable, as this backend used to, made that unrecoverable: KWallet's shim wedged
+        /// a process so completely that SIGINT would not end it, only SIGKILL (#74).
+        /// <para>
+        /// <c>g_cancellable_cancel</c> is thread-safe, so the token callback can fire it from
+        /// another thread while this one is blocked inside libsecret, and the call returns with
+        /// a cancelled GError.
+        /// </para>
+        /// </remarks>
+        private sealed class CancelScope : IDisposable
+        {
+            private readonly CancellationTokenRegistration _registration;
+
+            internal CancelScope(CancellationToken cancellationToken)
+            {
+                Handle = g_cancellable_new();
+                if (Handle == IntPtr.Zero)
+                {
+                    throw new InvalidOperationException("g_cancellable_new failed.");
+                }
+
+                // Registering an already-cancelled token invokes the callback immediately,
+                // so a pre-cancelled call is cancelled before libsecret is even entered.
+                _registration = cancellationToken.Register(
+                    static state => g_cancellable_cancel((IntPtr)state!), Handle);
+            }
+
+            internal IntPtr Handle { get; }
+
+            public void Dispose()
+            {
+                _registration.Dispose();
+                g_object_unref(Handle);
+            }
+        }
+
+        /// <summary>
+        /// Frees <paramref name="error"/> and throws — <see cref="OperationCanceledException"/>
+        /// when the caller cancelled, otherwise the usual wrapped GError.
+        /// </summary>
+        /// <remarks>
+        /// Cancellation is checked first on purpose. libsecret reports a cancelled call as a
+        /// GError, and reporting that as a generic "operation failed" would hide the fact that
+        /// the caller asked for it.
+        /// </remarks>
+        private static void ThrowIfCancelledOrGError(IntPtr error, string operation, CancellationToken cancellationToken)
+        {
+            if (error != IntPtr.Zero && cancellationToken.IsCancellationRequested)
+            {
+                g_error_free(error);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            ThrowIfGError(error, operation);
         }
 
         private static void ValidateProviderName(string providerName)
@@ -549,20 +623,21 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             public string? Secret { get; init; }
         }
 
-        private void StoreItem(Dictionary<string, string> attributes, string label, string password)
+        private void StoreItem(CancellationToken cancellationToken, Dictionary<string, string> attributes, string label, string password)
         {
             var attrs = NewAttributes(attributes);
             try
             {
+                using var cancel = new CancelScope(cancellationToken);
                 var status = secret_password_storev_sync(
                     IntPtr.Zero,
                     attrs,
                     _collection,
                     label,
                     password,
-                    IntPtr.Zero,
+                    cancel.Handle,
                     out var error);
-                ThrowIfGError(error, "secret_password_storev_sync");
+                ThrowIfCancelledOrGError(error, "secret_password_storev_sync", cancellationToken);
                 if (status == 0)
                 {
                     throw new InvalidOperationException("secret_password_storev_sync returned FALSE without a GError — the Secret Service may not be available.");
@@ -574,13 +649,14 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             }
         }
 
-        private static string? LookupPassword(Dictionary<string, string> attributes)
+        private static string? LookupPassword(CancellationToken cancellationToken, Dictionary<string, string> attributes)
         {
             var attrs = NewAttributes(attributes);
             try
             {
-                var result = secret_password_lookupv_sync(IntPtr.Zero, attrs, IntPtr.Zero, out var error);
-                ThrowIfGError(error, "secret_password_lookupv_sync");
+                using var cancel = new CancelScope(cancellationToken);
+                var result = secret_password_lookupv_sync(IntPtr.Zero, attrs, cancel.Handle, out var error);
+                ThrowIfCancelledOrGError(error, "secret_password_lookupv_sync", cancellationToken);
                 if (result == IntPtr.Zero)
                 {
                     return null;
@@ -617,13 +693,14 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         /// still in the keyring — a user revoking a leaked secret was told it was gone
         /// (#45).
         /// </remarks>
-        private static bool ClearItem(Dictionary<string, string> attributes)
+        private static bool ClearItem(CancellationToken cancellationToken, Dictionary<string, string> attributes)
         {
             var attrs = NewAttributes(attributes);
             try
             {
-                var removed = secret_password_clearv_sync(IntPtr.Zero, attrs, IntPtr.Zero, out var error);
-                ThrowIfGError(error, "secret_password_clearv_sync");
+                using var cancel = new CancelScope(cancellationToken);
+                var removed = secret_password_clearv_sync(IntPtr.Zero, attrs, cancel.Handle, out var error);
+                ThrowIfCancelledOrGError(error, "secret_password_clearv_sync", cancellationToken);
                 return removed != 0;
             }
             finally
@@ -632,14 +709,15 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
             }
         }
 
-        private static List<StoredItem> SearchItems(Dictionary<string, string> attributes, bool loadSecrets)
+        private static List<StoredItem> SearchItems(Dictionary<string, string> attributes, bool loadSecrets, CancellationToken cancellationToken)
         {
             var attrs = NewAttributes(attributes);
             var flags = SecretSearchAll | (loadSecrets ? SecretSearchLoadSecrets | SecretSearchUnlock : 0);
             try
             {
-                var listPtr = secret_password_searchv_sync(IntPtr.Zero, attrs, flags, IntPtr.Zero, out var error);
-                ThrowIfGError(error, "secret_password_searchv_sync");
+                using var cancel = new CancelScope(cancellationToken);
+                var listPtr = secret_password_searchv_sync(IntPtr.Zero, attrs, flags, cancel.Handle, out var error);
+                ThrowIfCancelledOrGError(error, "secret_password_searchv_sync", cancellationToken);
 
                 var results = new List<StoredItem>();
                 if (listPtr == IntPtr.Zero)
@@ -668,8 +746,8 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                         string? secret = null;
                         if (loadSecrets)
                         {
-                            var secretValue = secret_retrievable_retrieve_secret_sync(retrievable, IntPtr.Zero, out var secretError);
-                            ThrowIfGError(secretError, "secret_retrievable_retrieve_secret_sync");
+                            var secretValue = secret_retrievable_retrieve_secret_sync(retrievable, cancel.Handle, out var secretError);
+                            ThrowIfCancelledOrGError(secretError, "secret_retrievable_retrieve_secret_sync", cancellationToken);
                             try
                             {
                                 secret = ReadSecretValueAsString(secretValue);

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretInterop.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretInterop.cs
@@ -66,6 +66,20 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
         [LibraryImport(Libglib)]
         internal static partial void g_list_free(IntPtr list);
 
+        private const string Libgio = "libgio-2.0.so.0";
+
+        /// <summary>Creates a GCancellable. Release with <see cref="g_object_unref"/>.</summary>
+        [LibraryImport(Libgio)]
+        internal static partial IntPtr g_cancellable_new();
+
+        /// <summary>
+        /// Cancels a GCancellable. Thread-safe by contract, which is the whole point: it is
+        /// called from the cancellation-token callback while another thread sits blocked
+        /// inside a synchronous libsecret call, and it is what makes that call return.
+        /// </summary>
+        [LibraryImport(Libgio)]
+        internal static partial void g_cancellable_cancel(IntPtr cancellable);
+
         /// <summary>
         /// Frees a GList <b>and</b> each node's data, using <paramref name="freeFunc"/>.
         /// </summary>

--- a/src/NextIteration.SpectreConsole.Auth/Portability/CredentialPortabilityService.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Portability/CredentialPortabilityService.cs
@@ -52,16 +52,16 @@ namespace NextIteration.SpectreConsole.Auth.Portability
         /// Reads every stored credential and returns it as a passphrase-encrypted
         /// archive.
         /// </summary>
-        internal async Task<ExportResult> ExportAsync(string passphrase)
+        internal async Task<ExportResult> ExportAsync(string passphrase, CancellationToken cancellationToken = default)
         {
-            var credentials = await _manager.ExportCredentialsAsync().ConfigureAwait(false);
+            var credentials = await _manager.ExportCredentialsAsync(cancellationToken).ConfigureAwait(false);
             var bundle = CredentialArchive.Serialize(credentials, passphrase);
 
             // The backend drops credentials it cannot decrypt, so the archive may
             // hold fewer than the store does. Derive the difference from the
             // metadata listing rather than widening the public
             // ICredentialManager.ExportCredentialsAsync signature to report it.
-            var stored = await CountStoredCredentialsAsync().ConfigureAwait(false);
+            var stored = await CountStoredCredentialsAsync(cancellationToken).ConfigureAwait(false);
             return new ExportResult(bundle, credentials.Count, Math.Max(0, stored - credentials.Count));
         }
 
@@ -78,15 +78,17 @@ namespace NextIteration.SpectreConsole.Auth.Portability
         /// resolve it. Invoked only when there is an actual conflict. The existing
         /// side is metadata only — see <see cref="BuildConflictIndexAsync"/>.
         /// </param>
+        /// <param name="cancellationToken">Cancels the import.</param>
         internal async Task<ImportResult> ImportAsync(
             string bundle,
             string passphrase,
-            Func<CredentialExport, CredentialSummary, ConflictResolution> resolveConflict)
+            Func<CredentialExport, CredentialSummary, ConflictResolution> resolveConflict,
+            CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(resolveConflict);
 
             var incoming = CredentialArchive.Deserialize(bundle, passphrase);
-            var existingByKey = await BuildConflictIndexAsync().ConfigureAwait(false);
+            var existingByKey = await BuildConflictIndexAsync(cancellationToken).ConfigureAwait(false);
 
             var added = 0;
             var overwritten = 0;
@@ -105,13 +107,13 @@ namespace NextIteration.SpectreConsole.Auth.Portability
 
                     // Overwrite: drop the existing credential (which may carry a
                     // different account id) before restoring the incoming one.
-                    _ = await _manager.DeleteCredentialAsync(match.AccountId).ConfigureAwait(false);
-                    await _manager.RestoreCredentialAsync(entry).ConfigureAwait(false);
+                    _ = await _manager.DeleteCredentialAsync(match.AccountId, cancellationToken).ConfigureAwait(false);
+                    await _manager.RestoreCredentialAsync(entry, cancellationToken).ConfigureAwait(false);
                     overwritten++;
                 }
                 else
                 {
-                    await _manager.RestoreCredentialAsync(entry).ConfigureAwait(false);
+                    await _manager.RestoreCredentialAsync(entry, cancellationToken).ConfigureAwait(false);
                     added++;
                 }
             }
@@ -132,13 +134,13 @@ namespace NextIteration.SpectreConsole.Auth.Portability
         /// a single credential the local keystore cannot open aborted the entire
         /// import, which is exactly the store an import is meant to repair.
         /// </remarks>
-        private async Task<Dictionary<string, CredentialSummary>> BuildConflictIndexAsync()
+        private async Task<Dictionary<string, CredentialSummary>> BuildConflictIndexAsync(CancellationToken cancellationToken)
         {
             var index = new Dictionary<string, CredentialSummary>(StringComparer.Ordinal);
 
-            foreach (var provider in await _manager.GetProviderNamesAsync().ConfigureAwait(false))
+            foreach (var provider in await _manager.GetProviderNamesAsync(cancellationToken).ConfigureAwait(false))
             {
-                foreach (var summary in await _manager.ListCredentialsAsync(provider).ConfigureAwait(false))
+                foreach (var summary in await _manager.ListCredentialsAsync(provider, cancellationToken).ConfigureAwait(false))
                 {
                     // Duplicates on the same key are unusual but possible; keep the
                     // first as the conflict target.
@@ -155,12 +157,12 @@ namespace NextIteration.SpectreConsole.Auth.Portability
         /// Counts what the store holds, from metadata only, so an export can report
         /// how many credentials it had to leave out.
         /// </summary>
-        private async Task<int> CountStoredCredentialsAsync()
+        private async Task<int> CountStoredCredentialsAsync(CancellationToken cancellationToken)
         {
             var count = 0;
-            foreach (var provider in await _manager.GetProviderNamesAsync().ConfigureAwait(false))
+            foreach (var provider in await _manager.GetProviderNamesAsync(cancellationToken).ConfigureAwait(false))
             {
-                count += (await _manager.ListCredentialsAsync(provider).ConfigureAwait(false)).Count();
+                count += (await _manager.ListCredentialsAsync(provider, cancellationToken).ConfigureAwait(false)).Count();
             }
 
             return count;

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/NextIteration.SpectreConsole.Auth.Tests.csproj
@@ -19,6 +19,14 @@
 			CA2007 (ConfigureAwait) doesn't apply in test contexts; there
 			is no SynchronizationContext to recapture.
 
+			xUnit1051 (pass TestContext.Current.CancellationToken) fires at every call
+			into ICredentialManager now that its members accept a CancellationToken —
+			530 sites. The analyzer's benefit is making a cancelled test run stop
+			promptly; these tests are sub-second and the platform tears them down
+			anyway, so threading a token through every call would add noise far out of
+			proportion to that. Suppressed deliberately, not by accident. New tests
+			that specifically exercise cancellation pass a real token explicitly.
+
 			IDE0005 (remove unnecessary usings) only runs at build when
 			GenerateDocumentationFile is true — which a test project sets to
 			false (above). With EnforceCodeStyleInBuild on (STANDARD.md 1.2.1),
@@ -27,7 +35,7 @@
 			IDE0005 still gates the shipping project. STANDARD.md 2.7 needs the
 			matching amendment estate-wide.
 		-->
-		<NoWarn>$(NoWarn);CA1707;CA1515;CA2007;IDE0005</NoWarn>
+		<NoWarn>$(NoWarn);CA1707;CA1515;CA2007;IDE0005;xUnit1051</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -837,6 +837,28 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.False(listed.Single(c => c.AccountId == prod).IsSelected);
         }
 
+        [Fact]
+        public async Task Operations_HonourAnAlreadyCancelledToken()
+        {
+            using var temp = new TempDir();
+            var manager = CreateManager(temp.Path);
+            var id = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
+
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            // Every member takes a token as of 2.0.0 (#74); a cancelled one must surface as
+            // cancellation rather than being silently ignored.
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => manager.ListCredentialsAsync("Adobe", cts.Token));
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => manager.GetCredentialByIdAsync("Adobe", id, cts.Token));
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => manager.ExportCredentialsAsync(cts.Token));
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => manager.AddCredentialAsync("Adobe", "x", "Production", "{}", cts.Token));
+        }
+
         /// <summary>
         /// Minimal summary provider used only to verify that
         /// <see cref="FileCredentialManager.ListCredentialsAsync"/> routes

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/LibsecretCredentialManagerTests.cs
@@ -615,6 +615,24 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.False(listed.Single(c => c.AccountId == prod).IsSelected);
         }
 
+        [Fact]
+        [SupportedOSPlatform("linux")]
+        public async Task Operations_HonourAnAlreadyCancelledToken()
+        {
+            Assert.SkipWhen(_skip, SkipReason);
+
+            var manager = NewManager();
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            // The GCancellable is created from the token, so an already-cancelled token is
+            // cancelled before libsecret is entered (#74).
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => manager.AddCredentialAsync("Adobe", "prod", "Production", "{}", cts.Token));
+            _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => manager.ListCredentialsAsync("Adobe", cts.Token));
+        }
+
         private sealed class FakeAdobeSummaryProvider : ICredentialSummaryProvider
         {
             public string ProviderName => "Adobe";


### PR DESCRIPTION
Fixes #74. **Breaking — this makes the next release 2.0.0.**

## What changed

Every `ICredentialManager` member gains a trailing `CancellationToken cancellationToken = default`.

- **Callers are unaffected** — the parameter is optional, so existing consumer code compiles unchanged.
- **External implementations must update their signatures.** That is the breaking part.
- `ICredentialCollector` and `ICredentialSummaryProvider` are untouched, so **the provider packages are unaffected**.

The libsecret backend binds the token to a `GCancellable` per call. `g_cancellable_cancel` is thread-safe by contract, which is the whole point — it fires from the token callback while another thread sits blocked inside a synchronous libsecret call. A cancelled call surfaces as `OperationCanceledException` rather than a generic wrapped GError, because cancellation is checked before the GError is translated.

The Keychain backend honours the token at entry. `SecItem*` takes no cancellable, so there is no mid-call cancellation there — documented, not faked.

## It does not fix the KWallet wedge, and I checked rather than assumed

This is the part worth your attention. I instrumented the KWallet scenario to see whether cancellation actually escapes it:

```
main thread 1 entering AddCredentialAsync
  [4.0s] pool thread alive, requesting cancel
  [4.0s] token callback FIRED on thread 4
  [4.0s] cts.Cancel() returned
libsecret-WARNING: received unexpected result type ao from Completed signal instead of expected o
GLib-GIO-CRITICAL: GTask secret_service_real_prompt_async ... finalized without ever returning
```

The cancellation **works** — the callback fires, on time, on a pool thread, while the main thread is blocked. The call still never returns, because `ksecretd` emits the prompt's `Completed` signal with an `ao` payload where libsecret expects `o`. libsecret's prompt GTask is then abandoned without ever returning, so the nested main loop the synchronous wrapper runs never exits. **Cancellation cannot rescue a task libsecret has already given up on.**

That is an upstream libsecret/KWallet incompatibility. It is recorded in `LibsecretCredentialManager`'s remarks with the exact log lines, and the interface remarks now say plainly that honouring a token is not a guarantee every block is escapable. I had written the opposite in an earlier draft of these docs and corrected it once the experiment disproved it.

So: the API is now cancellable, which is what was chosen and is worth having. KWallet remains unsupported for the reason #19 already documented.

## Verification

Build clean, **416 tests** (358 passed, 58 skipped), up from 412.

New tests assert that an already-cancelled token surfaces as `OperationCanceledException` on both the file and libsecret backends — the libsecret one proves the `GCancellable` path is reached, since that is where the cancellation is observed.

## One suppression, deliberately

`xUnit1051` is now suppressed in the test project. It fires at **530** call sites into `ICredentialManager` the moment its members accept a token. Threading one through every existing assertion would bury the actual change in mechanical noise for a benefit — prompter teardown of sub-second tests — that does not apply here. The rationale is written into the csproj alongside the existing suppressions. New cancellation tests pass a real token explicitly.

## Not in this PR

The version bump. `[Unreleased]` records that this makes the next release 2.0.0; cutting it is a separate release PR, matching #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
