### PR TITLE
fix: resolve the three open CodeQL alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three CodeQL alerts introduced by this cycle's changes**, all in code added since 1.1.0.
+  `AtomicFile.WriteTempAsync` held its `FileStream` in a local before an `await using` block,
+  which the analyser could not prove disposed on every path (`cs/local-not-disposed`, the only
+  warning of the three) — it is now an `await using` declaration.
+  `LibsecretCredentialManager.ResolveStoredProviderName` used a filter-then-project loop where
+  LINQ says it plainly (`cs/linq/missed-select`), and a test paired `ContainsKey` with the
+  indexer instead of `TryGetValue` (`cs/inefficient-containskey`).
+
 - **The Keychain backend could see another CLI's credentials** (#55). App scoping was a
   dot-prefix match on the service string, and since the service is `{app}.{provider}` and
   provider names may contain dots, app `com.acme.cli` could not distinguish its own

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/AtomicFile.cs
@@ -68,11 +68,8 @@ namespace NextIteration.SpectreConsole.Auth.Persistence
                 options.UnixCreateMode = unixMode.Value;
             }
 
-            var stream = new FileStream(tempPath, options);
-            await using (stream.ConfigureAwait(false))
-            {
-                await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
-            }
+            await using var stream = new FileStream(tempPath, options);
+            await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Persistence/Libsecret/LibsecretCredentialManager.cs
@@ -511,17 +511,12 @@ namespace NextIteration.SpectreConsole.Auth.Persistence.Libsecret
                 },
                 loadSecrets: false, cancellationToken);
 
-            foreach (var item in items)
-            {
-                var stored = item.Attributes.GetValueOrDefault(AttrProvider);
-                if (!string.IsNullOrEmpty(stored) &&
+            return items
+                .Select(i => i.Attributes.GetValueOrDefault(AttrProvider))
+                .FirstOrDefault(stored =>
+                    !string.IsNullOrEmpty(stored) &&
                     stored.Equals(providerName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return stored;
-                }
-            }
-
-            return providerName;
+                ?? providerName;
         }
 
         /// <summary>

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/FileCredentialManagerTests.cs
@@ -314,8 +314,8 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             Assert.False(selections.ContainsKey("Adobe"));
 
             // And the delete must not disturb an unrelated provider's selection.
-            Assert.True(selections.ContainsKey("Airtable"));
-            Assert.Equal(unrelated, selections["Airtable"]);
+            Assert.True(selections.TryGetValue("Airtable", out var untouched));
+            Assert.Equal(unrelated, untouched);
 
             Assert.Null(await manager.GetSelectedCredentialAsync("Adobe"));
         }


### PR DESCRIPTION
Closes the three open code scanning alerts. All three are in code added during this cycle — none are pre-existing, so this is cleaning up after the recent work rather than paying down old debt.

| Alert | Rule | Severity | Where |
|---|---|---|---|
| #208 | `cs/local-not-disposed` | **warning** | `AtomicFile.cs:71` |
| #207 | `cs/linq/missed-select` | note | `LibsecretCredentialManager.cs:514` |
| #209 | `cs/inefficient-containskey` | note | `FileCredentialManagerTests.cs:317` |

## #208 — the only one that is more than style

`WriteTempAsync` assigned the `FileStream` to a local and then opened `await using (stream.ConfigureAwait(false))`. It *is* disposed in practice, but there is a window between construction and the `using` taking effect that the analyser cannot prove, and it was flagged accordingly. Rewritten as an `await using` **declaration**, which is provably correct and two lines shorter.

Worth noting this is code from the #54 permissions fix — the alert is a fair catch on my own change.

## #207 and #209 — notes

`ResolveStoredProviderName` ran a filter-then-project `foreach`; it now says so with `Select` + `FirstOrDefault`. A test paired `ContainsKey` with the indexer where `TryGetValue` is one lookup, and the `out` value makes the assertion read better.

## Verification

Build clean, **416 tests** (358 passed, 58 skipped) — unchanged. No behaviour change; the CodeQL run on this PR is the actual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
