### PR TITLE
test: retry the Keychain store-wide reads that raced their own writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Six Keychain tests could read the store before their writes were visible.** `main` went
+  red on `macos-14` with `GetProviderNamesAsync_ReturnsDistinctProviders` reporting
+  *"Expected: 2, Actual: 0"* — the same commit having passed that leg minutes earlier on the
+  PR. `AddCredentialAsync` confirms visibility through an exact service+account query, while
+  `ListCredentialsAsync` and `GetProviderNamesAsync` go through the class-wide query, so one
+  being visible does not imply the other. Fourteen reads in that file already used
+  `RetryHelper`; these six did not. Each now retries on the condition it actually asserts,
+  not merely on something having appeared — the distinction #61 turned on.
+
 ### Changed
 
 - **CI now runs three macOS versions and splits the libsecret tests into their own job**

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Persistence/KeychainCredentialManagerTests.cs
@@ -148,7 +148,11 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             var manager = NewManager();
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
 
-            var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
+            // Retried like its siblings: AddCredentialAsync confirms visibility through an
+            // exact service+account query, while these reads go through the class-wide
+            // query, so one being visible does not imply the other (#61's pattern).
+            var list = (await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"), r => r.Any(c => c.AccountId == accountId))).ToList();
 
             var credential = Assert.Single(list);
             Assert.Equal(accountId, credential.AccountId);
@@ -167,8 +171,13 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             _ = await manager.AddCredentialAsync("Adobe", "a1", "Production", "{}");
             _ = await manager.AddCredentialAsync("Airtable", "b1", "Production", "{}");
 
-            var adobe = (await manager.ListCredentialsAsync("Adobe")).ToList();
-            var airtable = (await manager.ListCredentialsAsync("Airtable")).ToList();
+            // Retried like its siblings: AddCredentialAsync confirms visibility through an
+            // exact service+account query, while these reads go through the class-wide
+            // query, so one being visible does not imply the other (#61's pattern).
+            var adobe = (await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"), r => r.Count() == 1)).ToList();
+            var airtable = (await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Airtable"), r => r.Count() == 1)).ToList();
 
             var adobeCredential = Assert.Single(adobe);
             var airtableCredential = Assert.Single(airtable);
@@ -255,7 +264,12 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
 
             _ = await manager.GetCredentialByIdAsync("Adobe", otherId);
 
-            var listings = (await manager.ListCredentialsAsync("Adobe")).ToList();
+            // Retried like its siblings: AddCredentialAsync confirms visibility through an
+            // exact service+account query, while these reads go through the class-wide
+            // query, so one being visible does not imply the other (#61's pattern).
+            var listings = (await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"),
+                r => r.Count() == 2 && r.Any(c => c.IsSelected))).ToList();
             Assert.True(listings.Single(c => c.AccountId == selectedId).IsSelected);
             Assert.False(listings.Single(c => c.AccountId == otherId).IsSelected);
         }
@@ -282,7 +296,11 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             var accountId = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{}");
 
             var deleted = await RetryHelper.UntilTrueAsync(() => manager.DeleteCredentialAsync(accountId));
-            var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
+            // Retried like its siblings: AddCredentialAsync confirms visibility through an
+            // exact service+account query, while these reads go through the class-wide
+            // query, so one being visible does not imply the other (#61's pattern).
+            var list = (await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"), r => !r.Any())).ToList();
 
             Assert.True(deleted);
             Assert.Empty(list);
@@ -334,7 +352,12 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             _ = await manager.AddCredentialAsync("Adobe", "a2", "Sandbox", "{}");
             _ = await manager.AddCredentialAsync("Airtable", "b1", "Production", "{}");
 
-            var names = (await manager.GetProviderNamesAsync()).ToList();
+            // This is the read that actually failed on macos-14, "Expected: 2, Actual: 0",
+            // and the one most exposed to the lag: GetProviderNamesAsync goes through the
+            // class-wide query while the adds confirmed themselves through an exact
+            // service+account query.
+            var names = (await RetryHelper.UntilAsync(
+                () => manager.GetProviderNamesAsync(), r => r.Count() == 2)).ToList();
 
             Assert.Equal(2, names.Count);
             Assert.Contains("Adobe", names);
@@ -415,7 +438,11 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Persistence
             var manager = NewManager([summaryProvider]);
 
             _ = await manager.AddCredentialAsync("Adobe", "prod", "Production", "{\"apiKey\":\"xyz\"}");
-            var list = (await manager.ListCredentialsAsync("Adobe")).ToList();
+            // Retried like its siblings: AddCredentialAsync confirms visibility through an
+            // exact service+account query, while these reads go through the class-wide
+            // query, so one being visible does not imply the other (#61's pattern).
+            var list = (await RetryHelper.UntilAsync(
+                () => manager.ListCredentialsAsync("Adobe"), r => r.Count() == 1)).ToList();
 
             var credential = Assert.Single(list);
             var field = Assert.Single(credential.DisplayFields);


### PR DESCRIPTION
Fixes the red `main`.

## What happened

The post-merge run of #78 failed on `test (macos-14)`:

```
failed KeychainCredentialManagerTests.GetProviderNamesAsync_ReturnsDistinctProviders
  Assert.Equal() Failure: Values differ
  Expected: 2
  Actual:   0
```

The same commit passed that same leg on the PR run minutes earlier, so it is timing rather than a regression. It is also **not** a consequence of the #55 owner-attribute change: when no owner is recorded `IsOwnedByThisApp` falls back to the prefix test, so filtering cannot zero the result.

## Root cause — the same mismatch as #61

`AddCredentialAsync` confirms its write is visible via `QuerySingleItem`, an **exact service+account** query. `ListCredentialsAsync` and `GetProviderNamesAsync` go through `QueryItems`/`QueryAllItemsForApp`, a **class-wide** query filtered in memory. Visibility to one does not imply visibility to the other, so a read on the second path can legitimately see nothing straight after a write confirmed on the first.

That is precisely the mismatch #61 fixed for the libsecret Restore test. Same shape, different file.

## The fix, and why six tests rather than one

Fourteen reads in `KeychainCredentialManagerTests` already used `RetryHelper`. **Six did not** — `GetProviderNamesAsync` was simply the one that lost the race first, and the other five were equally exposed. All six now retry.

Each predicate matches **what the test then asserts**, not merely that something appeared:

| Test | Predicate |
|---|---|
| `ListCredentialsAsync_ReturnsAddedCredential` | `r.Any(c => c.AccountId == accountId)` |
| `ListCredentialsAsync_FiltersByProvider` | `r.Count() == 1` per provider |
| `GetCredentialByIdAsync_DoesNotMutateSelection` | `r.Count() == 2 && r.Any(c => c.IsSelected)` |
| `DeleteCredentialAsync_RemovesCredential` | `!r.Any()` |
| `GetProviderNamesAsync_ReturnsDistinctProviders` | `r.Count() == 2` |
| `ListCredentialsAsync_IncludesDisplayFields_FromSummaryProvider` | `r.Count() == 1` |

A count-only predicate guarding a content assertion is exactly what let #61 through, so the third row waits on the selection being visible too, not just on two rows existing.

## Verification

Build clean, **416 tests** locally. The macOS legs are the ones that matter here and only CI runs them — worth watching `test (macos-14)` and `test (macos-15)` specifically on this PR, and on `main` after merge, since a timing fix cannot be proven by a single green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
