### PR TITLE
docs: fix the consumer sample, list Providers.GitHub, document version pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A third broken README snippet, missed by the first review pass.** The consumer sample —
+  the one showing how to use a token from a command handler, so among the most-copied code in
+  the file — does not compile against the Spectre.Console.Cli version this package depends on:
+  `AsyncCommand.ExecuteAsync` is `protected` and takes `(CommandContext, CancellationToken)`,
+  not a `public` `(CommandContext)`. Corrected and compiled. The install block also gained the
+  `Providers.GitHub` package, which the previous pass added to the table but not there, and a
+  version-pairing table was added: the providers cap at the major boundary, so `2.x` needs
+  `2.x`, and the cap exists to turn what would be a runtime `MissingMethodException` into a
+  restore-time resolution error.
+
+### Fixed
+
 - **README review ahead of 2.0.0: two broken snippets and nine stale or missing claims.**
   Both broken examples were verified by running them, and both replacements verified the same
   way. The DPAPI section registered the manager by type

--- a/README.md
+++ b/README.md
@@ -38,9 +38,24 @@ Pair it with one or more provider packages (or write your own — see [Extending
 dotnet add package NextIteration.SpectreConsole.Auth.Providers.Adobe
 dotnet add package NextIteration.SpectreConsole.Auth.Providers.Airtable
 dotnet add package NextIteration.SpectreConsole.Auth.Providers.SoftwareOne
+dotnet add package NextIteration.SpectreConsole.Auth.Providers.GitHub
 ```
 
 Targets `net8.0` and `net10.0`.
+
+**Pair matching major versions.** Each provider package depends on this one through a
+major-capped range, so `2.x` providers require `2.x` of this package and NuGet will refuse to
+mix them:
+
+| This package | Provider packages |
+|---|---|
+| `2.x` | `2.x` |
+| `1.x` | `1.0.1`+ |
+
+That refusal is deliberate and worth understanding. `ICredentialManager` changed shape in
+2.0.0, and the providers call into it — so a `1.x` provider assembly running against `2.x` of
+this package would fail at *runtime* with `MissingMethodException`. The version cap turns that
+into a resolution error you read at restore time instead.
 
 ---
 
@@ -91,7 +106,7 @@ And from inside any of your command handlers:
 ```csharp
 public sealed class SyncCommand(AdobeAuthenticationService auth) : AsyncCommand
 {
-    public override async Task<int> ExecuteAsync(CommandContext context)
+    protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
         var token = await auth.AuthenticateAsync();
         // use token.GetAuthorizationHeader() on outgoing requests


### PR DESCRIPTION
Follow-up to #80, now that the provider packages are being re-cut alongside 2.0.0.

## A third broken snippet — my first pass missed it

The consumer sample does not compile against the Spectre version this package depends on:

```
CS0534: 'SyncCommand' does not implement inherited abstract member
        'AsyncCommand.ExecuteAsync(CommandContext, CancellationToken)'
CS0507: cannot change access modifiers when overriding 'protected' inherited member
```

It declared `public override async Task<int> ExecuteAsync(CommandContext context)`. Spectre.Console.Cli 0.55's `AsyncCommand` takes `(CommandContext, CancellationToken)` and the member is `protected` — which is exactly what this repo's own commands do, so the sample was inconsistent with the code sitting next to it.

Corrected and **compiled against 0.55.0**, not eyeballed. Worth flagging that I reviewed this file end to end last time and still missed it: it is the sample showing how to use a token from a command handler, so probably the most-copied code in the README.

## Two additions for the coordinated release

**`Providers.GitHub`** was added to the packages table in #80 but not to the install block. Both now list it.

**Version pairing**, which is the thing most likely to bite on this release:

| This package | Provider packages |
|---|---|
| `2.x` | `2.x` |
| `1.x` | `1.0.1`+ |

Stated with the reason rather than as a bare rule: the providers call into `ICredentialManager`, which changed shape in 2.0.0, so a `1.x` provider assembly against `2.x` of this package would fail at runtime with `MissingMethodException`. The major cap turns that into a resolution error at restore time.

## Verification

Build clean, no code changed. The corrected sample compiles against Spectre.Console.Cli 0.55.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
