### PR TITLE
feat!: thread CancellationToken through IAuthenticationService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **`IAuthenticationService<,>` members now take a `CancellationToken`.** All three —
+  `AuthenticateAsync()`, `AuthenticateAsync(credential)` and `ValidateTokenAsync(token)` —
+  gain a trailing `CancellationToken cancellationToken = default`. Callers keep compiling;
+  the provider packages, which implement this interface, must update their signatures.
+
+  Done in the same release as the `ICredentialManager` change deliberately. This is the layer
+  that talks to the network — an OAuth2 token endpoint, a validation call — so it is where an
+  unbounded wait is most likely and least recoverable. Shipping cancellation on the storage
+  layer, which is local and fast, while leaving the network layer uncancellable would have put
+  it on the wrong half; and because both interfaces are provider-implemented, doing them apart
+  would have cost a second major version for no benefit.
+
+  The README's worked provider example is updated to match and is compiled verbatim against
+  the new interface, since it is the pattern the provider packages are built from.
+
 - **`ICredentialManager` members now take a `CancellationToken`** (#74). Every member gains a
   trailing `CancellationToken cancellationToken = default`. Existing *callers* keep compiling —
   the parameter is optional — but any external **implementation** of the interface must update

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ public sealed class SyncCommand(AdobeAuthenticationService auth) : AsyncCommand
 {
     protected override async Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken)
     {
-        var token = await auth.AuthenticateAsync();
+        var token = await auth.AuthenticateAsync(cancellationToken);
         // use token.GetAuthorizationHeader() on outgoing requests
         return 0;
     }
@@ -242,18 +242,18 @@ public sealed class GitHubToken : IToken
 public sealed class GitHubAuthenticationService(ICredentialManager manager)
     : IAuthenticationService<GitHubCredential, GitHubToken>
 {
-    public async Task<GitHubToken> AuthenticateAsync()
+    public async Task<GitHubToken> AuthenticateAsync(CancellationToken cancellationToken = default)
     {
-        var json = await manager.GetSelectedCredentialAsync(GitHubCredential.ProviderName)
+        var json = await manager.GetSelectedCredentialAsync(GitHubCredential.ProviderName, cancellationToken)
             ?? throw new InvalidOperationException("No GitHub credential selected");
         var credential = JsonSerializer.Deserialize<GitHubCredential>(json)!;
-        return await AuthenticateAsync(credential);
+        return await AuthenticateAsync(credential, cancellationToken);
     }
 
-    public Task<GitHubToken> AuthenticateAsync(GitHubCredential credential) =>
+    public Task<GitHubToken> AuthenticateAsync(GitHubCredential credential, CancellationToken cancellationToken = default) =>
         Task.FromResult(new GitHubToken { AccessToken = credential.PersonalAccessToken });
 
-    public Task<bool> ValidateTokenAsync(GitHubToken token) =>
+    public Task<bool> ValidateTokenAsync(GitHubToken token, CancellationToken cancellationToken = default) =>
         Task.FromResult(!token.IsExpired);
 }
 

--- a/src/NextIteration.SpectreConsole.Auth/Services/IAuthenticationService.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Services/IAuthenticationService.cs
@@ -10,6 +10,14 @@ namespace NextIteration.SpectreConsole.Auth.Services
     /// </summary>
     /// <typeparam name="TCredential">The concrete credential type for this provider.</typeparam>
     /// <typeparam name="TToken">The concrete token type for this provider.</typeparam>
+    /// <remarks>
+    /// Every member takes a <see cref="CancellationToken"/> and implementations are expected
+    /// to honour it. This is the layer that talks to the network — an OAuth2 token endpoint,
+    /// a validation call — so it is where an unbounded wait is most likely and least
+    /// recoverable. <see cref="Persistence.ICredentialManager"/> gained cancellation for the
+    /// same reason; leaving it off here would have made the storage layer, which is local and
+    /// fast, the only cancellable half.
+    /// </remarks>
     public interface IAuthenticationService<TCredential, TToken>
         where TCredential : ICredential
         where TToken : IToken
@@ -18,22 +26,27 @@ namespace NextIteration.SpectreConsole.Auth.Services
         /// Authenticates using whichever credential is currently selected
         /// for this provider via <see cref="Persistence.ICredentialManager.SelectCredentialAsync"/>.
         /// </summary>
+        /// <param name="cancellationToken">Cancels the lookup and the authentication call.</param>
         /// <exception cref="InvalidOperationException">
         /// No credential is currently selected for this provider, or the
         /// stored credential failed to deserialize.
         /// </exception>
-        Task<TToken> AuthenticateAsync();
+        Task<TToken> AuthenticateAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Authenticates using the supplied credential directly, bypassing
         /// the selection mechanism.
         /// </summary>
-        Task<TToken> AuthenticateAsync(TCredential credential);
+        /// <param name="credential">The credential to authenticate with.</param>
+        /// <param name="cancellationToken">Cancels the authentication call.</param>
+        Task<TToken> AuthenticateAsync(TCredential credential, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns <see langword="true"/> when the supplied token is still
         /// valid (not expired and not revoked by the provider).
         /// </summary>
-        Task<bool> ValidateTokenAsync(TToken token);
+        /// <param name="token">The token to check.</param>
+        /// <param name="cancellationToken">Cancels the validation call.</param>
+        Task<bool> ValidateTokenAsync(TToken token, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
**Breaking**, and deliberately in the same major as #76 rather than after it.

## What changed

All three `IAuthenticationService<,>` members gain a trailing `CancellationToken cancellationToken = default`:

```csharp
Task<TToken> AuthenticateAsync(CancellationToken cancellationToken = default);
Task<TToken> AuthenticateAsync(TCredential credential, CancellationToken cancellationToken = default);
Task<bool>   ValidateTokenAsync(TToken token, CancellationToken cancellationToken = default);
```

Callers keep compiling. The **provider packages implement this interface**, so they must update their signatures — which is why this is landing now, while they are being rebuilt for 2.0.0 anyway.

## Why it belongs in this major

#76 made the *storage* layer cancellable: local filesystem or OS keychain work, fast, rarely blocking. This is the layer that makes **network calls** — Adobe's OAuth2 token endpoint, a validation round trip. An unbounded wait is both more likely and less recoverable here.

Shipping cancellation on the storage half while leaving the network half uncancellable would have put it on the wrong half of the library. And since both interfaces are provider-implemented, splitting them across releases would have cost a **3.0.0** for no benefit — the same rebuild covers both today.

## Verification

Build clean, **416 tests** unchanged — nothing in this repo implements `IAuthenticationService`, so there is no internal call site.

The more useful check: the README's worked provider example is **extracted verbatim from the markdown and compiled** against the new interface. That sample is the pattern the provider packages are written from, so a sample that did not compile would propagate straight into them — which is exactly how the broken `SyncCommand` snippet survived until #81.

The consumer sample now threads its command's `CancellationToken` into `AuthenticateAsync`, which is the whole point of the change.

## Note

`ICredentialCollector.CollectAsync()` is the one remaining provider-implemented member without a token — see the PR discussion; I have deliberately not changed it without your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
