### PR TITLE
test: ride out transient store rejections, and test the retry helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The test retry helper now rides out a transient store rejection, not just a late answer.**
+  `main` went red on `macos-14` with `SecItemCopyMatching failed: OSStatus -67701`; re-running
+  the identical commit passed. `RetryHelper` retried on a false *result* but did not catch
+  exceptions, so a store that rejected a query outright — rather than answering it late —
+  escaped the loop on the first attempt. Both helpers now treat an `InvalidOperationException`
+  as a failed attempt, guarded by `when (attempt < maxAttempts)` so the final attempt is not
+  caught: a persistent failure still fails the test with its real message, only a transient one
+  is ridden out. `RetryHelper` has its own tests now, since a retry helper that swallowed a
+  persistent failure would make every test using it incapable of failing.
+
 - **A third broken README snippet, missed by the first review pass.** The consumer sample —
   the one showing how to use a token from a command handler, so among the most-copied code in
   the file — does not compile against the Spectre.Console.Cli version this package depends on:

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelper.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelper.cs
@@ -9,6 +9,15 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Infrastructure
     /// That is a store-visibility timing artifact of the tests running side by
     /// side, not a defect in the manager, so it is closed here rather than by
     /// making the production delete path slower.
+    /// <para>
+    /// The same concurrency also makes the store occasionally <b>reject</b> a query
+    /// outright rather than merely answer it late — <c>SecItemCopyMatching</c> returning
+    /// <c>OSStatus -67701</c> on a macOS runner, surfacing as an
+    /// <see cref="InvalidOperationException"/> from the backend. Both helpers therefore
+    /// treat such an exception as a failed attempt and try again, but <b>rethrow it if the
+    /// final attempt still fails</b>. A persistent error still fails the test with its real
+    /// message; only a transient one is ridden out.
+    /// </para>
     /// </summary>
     internal static class RetryHelper
     {
@@ -25,9 +34,18 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Infrastructure
         {
             for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
-                if (await action())
+                try
                 {
-                    return true;
+                    if (await action())
+                    {
+                        return true;
+                    }
+                }
+                catch (InvalidOperationException) when (attempt < maxAttempts)
+                {
+                    // Transient store rejection; fall through to the delay and retry. The
+                    // `when` guard is what keeps this honest — on the final attempt the
+                    // exception is not caught, so a persistent failure still surfaces.
                 }
 
                 if (attempt < maxAttempts)
@@ -54,11 +72,29 @@ namespace NextIteration.SpectreConsole.Auth.Tests.Infrastructure
             int maxAttempts = 20,
             int delayMs = 25)
         {
-            var result = await action();
-            for (var attempt = 1; !predicate(result) && attempt < maxAttempts; attempt++)
+            T result = default!;
+            var satisfied = false;
+
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
             {
+                try
+                {
+                    result = await action();
+                    satisfied = predicate(result);
+                }
+                catch (InvalidOperationException) when (attempt < maxAttempts)
+                {
+                    // Transient store rejection — see the type remarks. Not caught on the
+                    // final attempt, so a persistent failure still reaches the test.
+                    satisfied = false;
+                }
+
+                if (satisfied || attempt == maxAttempts)
+                {
+                    break;
+                }
+
                 await Task.Delay(delayMs);
-                result = await action();
             }
 
             return result;

--- a/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelperTests.cs
+++ b/tests/NextIteration.SpectreConsole.Auth.Tests/Infrastructure/RetryHelperTests.cs
@@ -1,0 +1,104 @@
+using NextIteration.SpectreConsole.Auth.Tests.Infrastructure;
+
+using Xunit;
+
+namespace NextIteration.SpectreConsole.Auth.Tests.Infrastructure
+{
+    /// <summary>
+    /// Tests for the retry helper itself. It stopped being a trivial loop once it began
+    /// swallowing exceptions, and a retry helper that quietly swallows a persistent failure
+    /// would turn every test that uses it into a test that cannot fail — the exact vacuity
+    /// this suite has been cleaning up. These pin the boundary.
+    /// </summary>
+    public sealed class RetryHelperTests
+    {
+        [Fact]
+        public async Task UntilTrueAsync_RidesOutATransientThrow()
+        {
+            var attempts = 0;
+
+            var result = await RetryHelper.UntilTrueAsync(() =>
+            {
+                attempts++;
+                return attempts < 3
+                    ? throw new InvalidOperationException("SecItemCopyMatching failed: OSStatus -67701.")
+                    : Task.FromResult(true);
+            }, maxAttempts: 5, delayMs: 1);
+
+            Assert.True(result);
+            Assert.Equal(3, attempts);
+        }
+
+        [Fact]
+        public async Task UntilTrueAsync_RethrowsWhenEveryAttemptThrows()
+        {
+            var attempts = 0;
+
+            // The load-bearing case: a persistent failure must still fail the test, with its
+            // real message, rather than being reported as a benign "false".
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => RetryHelper.UntilTrueAsync(() =>
+                {
+                    attempts++;
+                    throw new InvalidOperationException("persistent");
+                }, maxAttempts: 3, delayMs: 1));
+
+            Assert.Equal("persistent", ex.Message);
+            Assert.Equal(3, attempts);
+        }
+
+        [Fact]
+        public async Task UntilAsync_RidesOutATransientThrow()
+        {
+            var attempts = 0;
+
+            var result = await RetryHelper.UntilAsync(() =>
+            {
+                attempts++;
+                return attempts < 3
+                    ? throw new InvalidOperationException("transient")
+                    : Task.FromResult(42);
+            }, r => r == 42, maxAttempts: 5, delayMs: 1);
+
+            Assert.Equal(42, result);
+            Assert.Equal(3, attempts);
+        }
+
+        [Fact]
+        public async Task UntilAsync_RethrowsWhenEveryAttemptThrows()
+        {
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => RetryHelper.UntilAsync<int>(
+                    () => throw new InvalidOperationException("persistent"),
+                    r => true, maxAttempts: 3, delayMs: 1));
+
+            Assert.Equal("persistent", ex.Message);
+        }
+
+        [Fact]
+        public async Task UntilAsync_ReturnsTheLastResultWhenThePredicateNeverHolds()
+        {
+            var attempts = 0;
+
+            // Unchanged behaviour, pinned because the rewrite could easily have lost it:
+            // the caller's own assertion must report the real value, not a timeout.
+            var result = await RetryHelper.UntilAsync(() =>
+            {
+                attempts++;
+                return Task.FromResult(attempts);
+            }, r => false, maxAttempts: 4, delayMs: 1);
+
+            Assert.Equal(4, attempts);
+            Assert.Equal(4, result);
+        }
+
+        [Fact]
+        public async Task UntilTrueAsync_ReturnsFalseWhenTheTargetIsGenuinelyAbsent()
+        {
+            var result = await RetryHelper.UntilTrueAsync(
+                () => Task.FromResult(false), maxAttempts: 3, delayMs: 1);
+
+            Assert.False(result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the red `main`.

## What happened

```
KeychainCredentialManagerTests.SelectAndGetSelected_RoundTripsDecryptedPayload
  InvalidOperationException : SecItemCopyMatching failed: OSStatus -67701.
```

Re-running the **identical commit** passed, and `macos-15` passed it first time. So it is environmental — and it is not from #82, which touches nothing in the Keychain path. It is the concurrent-shared-keychain exposure that NextIteration.Standards' TODO already documents for multi-targeted test projects (net8.0 and net10.0 run as two processes against one login keychain), now more visible with a second macOS leg.

## The gap

`RetryHelper` retried on a false *result* but never caught exceptions. So a store that **rejected** a query — rather than answering it late — escaped the loop on the very first attempt. Every existing use was protected against slowness and not against rejection.

Both helpers now treat `InvalidOperationException` as a failed attempt.

## The guard that keeps this honest

```csharp
catch (InvalidOperationException) when (attempt < maxAttempts)
```

The final attempt is **not** caught, so a persistent failure still reaches the test with its real message. Without that condition this would be a helper that makes every test using it incapable of failing — precisely the vacuity the last several PRs have been removing, and it would have been a bad trade to introduce it while fixing a flake.

## RetryHelper now has its own tests

It stopped being a trivial loop the moment it began swallowing exceptions. Six tests pin the boundary:

- a transient throw is ridden out, and the attempt count proves it retried;
- **a persistent throw is rethrown, with its message intact** — the load-bearing one;
- the predicate-never-holds path still returns the last result, so the caller's assertion reports the real value rather than a timeout (unchanged behaviour, pinned because the rewrite could easily have lost it);
- a genuinely absent target still returns false.

## Verification

Build clean, **428 tests** (370 passed, 58 skipped), up from 416. Production code untouched — this is a test artifact, and the helper's own docs already argue against slowing the production delete path to accommodate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
