### PR TITLE
feat!: thread CancellationToken through ICredentialCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **`ICredentialCollector.CollectAsync()` now takes a `CancellationToken`.** Callers keep
+  compiling; the provider packages, which implement it, must update their signature. This is
+  the last provider-implemented member that could not be cancelled, and it waits on a human —
+  an unbounded wait by definition — so `accounts add` could not be interrupted mid-prompt even
+  though `AddCredentialCommand` had a token in hand the whole time. Spectre.Console's
+  `PromptAsync`/`ConfirmAsync` already accept one; the parameter just had nowhere to come from.
+
+  `ICredentialSummaryProvider.GetDisplayFields` is deliberately left alone: it is synchronous,
+  pure projection over an in-memory string, and has no I/O to cancel.
+
 - **`IAuthenticationService<,>` members now take a `CancellationToken`.** All three —
   `AuthenticateAsync()`, `AuthenticateAsync(credential)` and `ValidateTokenAsync(token)` —
   gain a trailing `CancellationToken cancellationToken = default`. Callers keep compiling;

--- a/README.md
+++ b/README.md
@@ -262,10 +262,11 @@ public sealed class GitHubCredentialCollector : ICredentialCollector
 {
     public string ProviderName => GitHubCredential.ProviderName;
 
-    public async Task<(string credentialData, string environment)> CollectAsync()
+    public async Task<(string credentialData, string environment)> CollectAsync(
+        CancellationToken cancellationToken = default)
     {
         var pat = await AnsiConsole.PromptAsync(
-            new TextPrompt<string>("GitHub personal access token:").Secret());
+            new TextPrompt<string>("GitHub personal access token:").Secret(), cancellationToken);
         var credential = new GitHubCredential
         {
             PersonalAccessToken = pat,

--- a/src/NextIteration.SpectreConsole.Auth/Commands/AddCredentialCommand.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/AddCredentialCommand.cs
@@ -77,7 +77,7 @@ namespace NextIteration.SpectreConsole.Auth.Commands
                             .Validate(name => !string.IsNullOrWhiteSpace(name)), cancellationToken).ConfigureAwait(false);
                 }
 
-                var (credentialData, environment) = await collector.CollectAsync().ConfigureAwait(false);
+                var (credentialData, environment) = await collector.CollectAsync(cancellationToken).ConfigureAwait(false);
 
                 var accountId = await _credentialManager.AddCredentialAsync(
                     collector.ProviderName,

--- a/src/NextIteration.SpectreConsole.Auth/Commands/ICredentialCollector.cs
+++ b/src/NextIteration.SpectreConsole.Auth/Commands/ICredentialCollector.cs
@@ -17,6 +17,12 @@ namespace NextIteration.SpectreConsole.Auth.Commands
         /// Prompts the user for the credential details and returns the serialized
         /// credential JSON together with the selected environment name.
         /// </summary>
-        Task<(string credentialData, string environment)> CollectAsync();
+        /// <param name="cancellationToken">
+        /// Cancels the prompts. Pass it to Spectre.Console's <c>PromptAsync</c> /
+        /// <c>ConfirmAsync</c> overloads — an implementation that ignores it leaves
+        /// <c>accounts add</c> unable to be interrupted while it waits for input, which is
+        /// unbounded by nature since it waits on a human.
+        /// </param>
+        Task<(string credentialData, string environment)> CollectAsync(CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
**Breaking.** Completes the cancellation work for 2.0.0.

## What changed

```csharp
Task<(string credentialData, string environment)> CollectAsync(CancellationToken cancellationToken = default);
```

Callers keep compiling. The **provider packages implement this**, so they update their signature — landing now while they are being rebuilt anyway.

## Why this one matters

It is the last provider-implemented member that could not be cancelled, and it is the one that **waits on a human** — unbounded by definition. `accounts add` could not be interrupted mid-prompt even though `AddCredentialCommand` had a `CancellationToken` in hand the entire time, and Spectre's `PromptAsync`/`ConfirmAsync` already accept one. The parameter simply had nowhere to come from.

Together with #76 (`ICredentialManager`) and #82 (`IAuthenticationService`), all three provider-facing interfaces are now cancellable, in one major. Split across releases they would have cost three majors for a single capability.

## What is deliberately not changed

`ICredentialSummaryProvider.GetDisplayFields` is synchronous, pure projection over an in-memory string, with no I/O to cancel. A token there would be ceremony, and it would make the providers' rebuild larger for nothing.

## Verification

Build clean, **428 tests** (370 passed, 58 skipped).

The README's worked provider example — collector included — is **extracted verbatim from the markdown and compiled** against the new interfaces. That sample is the template the provider packages are written from, so it needs to be correct before you cut them, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
