### PR TITLE
release: 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-08-28
+
+Major release. **Three provider-facing interfaces gain a `CancellationToken`** —
+`ICredentialManager`, `IAuthenticationService<,>` and `ICredentialCollector`. Callers keep
+compiling, since every added parameter is optional; **implementations must update their
+signatures**, which is why the provider packages are re-cut alongside this release. They are
+capped at the major boundary, so a 1.x provider cannot resolve against 2.0.0 — that refusal is
+deliberate, and turns what would be a runtime `MissingMethodException` into a restore-time
+error.
+
+Doing all three in one major was the point: split across releases they would have cost three.
+
+Beyond the API, this release is mostly the output of a full adversarial review of the
+codebase. The findings worth calling out: two concurrent first runs could **silently destroy
+one set of credentials**; the libsecret backend reported a **successful delete when nothing
+was deleted**; the Keychain backend could **see and delete another CLI's credentials**; and a
+credential the local keystore could no longer open would **vanish from `accounts list`** or
+take the whole listing down with it. Several test-integrity defects are fixed too, including a
+libsecret suite that disabled itself whenever the code it tested regressed.
+
 ### Breaking
 
 - **`ICredentialCollector.CollectAsync()` now takes a `CancellationToken`.** Callers keep
@@ -827,7 +847,8 @@ Consumers needed a way to read a specific stored credential's secret at runtime 
 - SourceLink, deterministic builds, embedded symbols, published symbol packages.
 - `TreatWarningsAsErrors=true`, `AnalysisLevel=latest` — zero-warning public API.
 
-[Unreleased]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v2.0.0
 [1.1.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v1.1.0
 [1.0.1]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v1.0.1
 [1.0.0]: https://github.com/StuartMeeks/NextIteration.SpectreConsole.Auth/releases/tag/v1.0.0

--- a/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
+++ b/src/NextIteration.SpectreConsole.Auth/NextIteration.SpectreConsole.Auth.csproj
@@ -12,7 +12,7 @@
 
 	<PropertyGroup>
 		<PackageId>NextIteration.SpectreConsole.Auth</PackageId>
-		<Version>1.1.0</Version>
+		<Version>2.0.0</Version>
 		<Description>Credential storage, encryption, and Spectre.Console CLI commands for managing provider credentials in CLI tools.</Description>
 		<GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
 		<PackageOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\packages</PackageOutputPath>


### PR DESCRIPTION
Cuts **2.0.0**. Version bump, `[Unreleased]` → `[2.0.0] — 2026-08-28`, link refs.

## Why major

Three provider-facing interfaces gain a `CancellationToken`:

| Interface | Members |
|---|---|
| `ICredentialManager` | all 9 |
| `IAuthenticationService<,>` | all 3 |
| `ICredentialCollector` | `CollectAsync` |

Every added parameter is optional, so **callers keep compiling**. **Implementations must update their signatures** — which is why the four provider packages are being re-cut alongside this.

The providers cap at the major boundary, so a 1.x provider **cannot resolve** against 2.0.0. That refusal is the point: the providers call `ICredentialManager`, so a 1.x assembly against 2.x would fail at runtime with `MissingMethodException`. The cap turns that into a restore-time error you can read.

## What else is in it

Mostly the output of a full adversarial review of the codebase — 26 entries. The ones that matter most:

- **Two concurrent first runs could silently destroy one set of credentials** (#44) — unrecoverable, and it presented as the same "failed integrity check" message a keystore copied between machines produces.
- **libsecret reported a successful delete when nothing was deleted** (#45) — worst possible answer for someone revoking a leaked credential.
- **The Keychain backend could see and delete another CLI's credentials** (#55) — dot-prefix app scoping.
- **An unreadable credential vanished from `accounts list`** (#52) or took the whole listing down (#38), hiding the id needed to remove it.
- Test-integrity fixes, including a libsecret suite that **disabled itself whenever the code it tested regressed** (#46).

## Verification

Build clean, **428 tests** (370 passed, 58 skipped) on both TFMs. `dotnet build` produced `NextIteration.SpectreConsole.Auth.2.0.0.nupkg` + `.snupkg`, which is the real confirmation the bump took.

After merge: tag `v2.0.0` on the squashed commit, which fires the `publish` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
